### PR TITLE
modified templates to dereference class parameters

### DIFF
--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -2,11 +2,11 @@
 ### File managed by Puppet
 ###
 
-#rocommunity <%= scope.lookupvar('snmp::params::ro_community') %> <%= scope.lookupvar('snmp::params::ro_network') %>
-#rwcommunity <%= scope.lookupvar('snmp::params::rw_community') %> <%= scope.lookupvar('snmp::params::rw_network') %>
+#rocommunity <%= scope.lookupvar('snmp::server::ro_community') %> <%= scope.lookupvar('snmp::server::ro_network') %>
+#rwcommunity <%= scope.lookupvar('snmp::server::rw_community') %> <%= scope.lookupvar('snmp::server::rw_network') %>
 #sysservices 76
 
-com2sec notConfigUser  default       <%= scope.lookupvar('snmp::params::ro_community') %>
+com2sec notConfigUser  default       <%= scope.lookupvar('snmp::server::ro_community') %>
 
 group   notConfigGroup v1            notConfigUser
 group   notConfigGroup v2c           notConfigUser
@@ -16,8 +16,8 @@ view    systemview    included   .1.3.6.1.2.1.25.1.1
 
 access  notConfigGroup ""      any       noauth    exact  systemview none none
 
-syslocation <%= scope.lookupvar('snmp::params::location') %>
-syscontact <%= scope.lookupvar('snmp::params::contact') %>
+syslocation <%= scope.lookupvar('snmp::server::location') %>
+syscontact <%= scope.lookupvar('snmp::server::contact') %>
 
 dontLogTCPWrappersConnects yes
 

--- a/templates/snmptrapd.conf.erb
+++ b/templates/snmptrapd.conf.erb
@@ -1,5 +1,5 @@
 ###
 ### File managed by Puppet
 ###
-authCommunity   log,execute,net <%= scope.lookupvar('snmp::params::ro_community') %>
+authCommunity   log,execute,net <%= scope.lookupvar('snmp::trapd::ro_community') %>
 # traphandle SNMPv2-MIB::coldStart    /usr/bin/bin/my_great_script cold


### PR DESCRIPTION
Hardcoding references to `$snmpd::params::foo` in the templates means that
the parameters passed into the class get dropped on the floor. :)

This patch replaces these references with the corresponding 
`$snmpd::<submodule>::foo` reference.
