### PR TITLE
$snmp::server::visible_oids parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,8 +33,8 @@
 # Copyright (C) 2012 Mike Arnold, unless otherwise noted.
 #
 class snmp (
-  $ensure      = 'present',
-  $autoupgrade = false
+  $ensure       = 'present',
+  $autoupgrade  = false
 ) inherits snmp::params {
 
   case $ensure {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class snmp::params {
   $rw_network   = '127.0.0.1'
   $contact      = 'Unknown'
   $location     = 'Unknown'
+  $visible_oids = [ '.1.3.6.1.2.1.1', '.1.3.6.1.2.1.25.1.1', ]
 
 # These should not need to be changed.
   case $::operatingsystem {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -64,6 +64,10 @@
 #   Service has restart command.
 #   Default: true
 #
+# [*visible_oids*]
+#   String or array of strings describing OIDs to be exposed via snmpd.
+#   Default: [ '.1.3.6.1.2.1.1', '.1.3.6.1.2.1.25.1.1', ]
+#
 # === Actions:
 #
 # Installs the SNMP daemon package, service, and configuration.
@@ -100,7 +104,8 @@ class snmp::server (
   $service_name       = $snmp::params::service_name,
   $service_enable     = true,
   $service_hasstatus  = true,
-  $service_hasrestart = true
+  $service_hasrestart = true,
+  $visible_oids       = $snmp::params::visible_oids
 ) inherits snmp::params {
   include snmp
 

--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -11,8 +11,9 @@ com2sec notConfigUser  default       <%= scope.lookupvar('snmp::server::ro_commu
 group   notConfigGroup v1            notConfigUser
 group   notConfigGroup v2c           notConfigUser
 
-view    systemview    included   .1.3.6.1.2.1.1
-view    systemview    included   .1.3.6.1.2.1.25.1.1
+<% Array(visible_oids).each do |oid| -%>
+view    systemview    included   <%= oid %>
+<% end -%>
 
 access  notConfigGroup ""      any       noauth    exact  systemview none none
 


### PR DESCRIPTION
This parameter permits passing a string or array of strings that specify OIDs to be exposed via snmpd.  The defaults are unchanged from the way the template had previously been written.
