### PR TITLE
Create 'services' parameter to snmp class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -214,6 +214,7 @@ class snmp (
   $rw_network              = $snmp::params::rw_network,
   $contact                 = $snmp::params::contact,
   $location                = $snmp::params::location,
+  $services                = $snmp::params::services,
   $views                   = $snmp::params::views,
   $accesses                = $snmp::params::accesses,
   $dlmod                   = $snmp::params::dlmod,


### PR DESCRIPTION
All the work was done for this already, in the `$snmp::params` class.  It was even already documented, but just not in the parameter list.
