### PR TITLE
Added support for com2sec source definitions for the RO community.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,11 @@
 #   Network that is allowed to RW query the daemon.
 #   Default: 127.0.0.1
 #
+# [*ro_sources*]
+#   VACM com2sec sources (hostnames, IPs, or IP ranges) allowed to RO query the daemon.
+#   See http://www.net-snmp.org/docs/man/snmpd.conf.html#lbAL for details.
+#   Default: [ 'default' ]
+#
 # [*contact*]
 #   Responsible person for the SNMP system.
 #   Default: Unknown
@@ -212,6 +217,7 @@ class snmp (
   $rw_community            = $snmp::params::rw_community,
   $ro_network              = $snmp::params::ro_network,
   $rw_network              = $snmp::params::rw_network,
+  $ro_sources              = $snmp::params::ro_sources,
   $contact                 = $snmp::params::contact,
   $location                = $snmp::params::location,
   $views                   = $snmp::params::views,
@@ -253,6 +259,7 @@ class snmp (
   validate_array($trap_handlers)
   validate_array($trap_forwards)
   validate_array($snmp_config)
+  validate_array($ro_sources)
   validate_array($views)
   validate_array($accesses)
   validate_array($dlmod)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,6 +46,13 @@ class snmp::params {
     default => $::snmp_rw_network,
   }
 
+  $ro_sources = $::snmp_ro_sources ? {
+    undef   => [
+      'default',
+    ],
+    default => $::snmp_ro_sources,
+  }
+
   $contact = $::snmp_contact ? {
     undef   => 'Unknown',
     default => $::snmp_contact,

--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -22,7 +22,9 @@ agentaddress <%= @agentaddress.join(',') %>
 # ------------------------------------------------------------------------------
 # VACM Configuration
 #       sec.name       source        community
-com2sec notConfigUser  default       <%= @ro_community %>
+<% @ro_sources.each do |ro_source| -%>
+com2sec notConfigUser  <%= ro_source %>     <%= @ro_community %>
+<% end -%>
 
 #       groupName      securityModel securityName
 group   notConfigGroup v1            notConfigUser


### PR DESCRIPTION
The value defaults to an array containing 'default', but can be set to hostnames, IP addresses, or IP ranges as defined in the net-snmp docs: http://www.net-snmp.org/docs/man/snmpd.conf.html#lbAL

The default value should prevent any issues with upgrading puppet-snmp, as the end-result configuration should be the same in that case.

I understand this may somewhat conflict with the eventual intended functionality of ro_network, but that's why I used a different variable.
