### PR TITLE
Tweaked $::osfamily calls in init.pp and params to make the module work on SLES 11

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -281,7 +281,7 @@ class snmp (
       if $service_ensure in [ running, stopped ] {
         # Make sure that if $trap_service_ensure == 'running' that
         # $service_ensure_real == 'running' on Debian.
-        if ($::osfamily == 'Debian') and ($trap_service_ensure_real == 'running') {
+        if ($snmp::params::osfamily == 'Debian') and ($trap_service_ensure_real == 'running') {
           $service_ensure_real = $trap_service_ensure_real
           $service_enable_real = $trap_service_enable_real
         } else {
@@ -316,7 +316,7 @@ class snmp (
     $trapdrun = 'no'
   }
 
-  if $::osfamily != 'Debian' {
+  if $snmp::params::osfamily != 'Debian' {
     $snmptrapd_conf_notify = Service['snmptrapd']
   } else {
     $snmptrapd_conf_notify = Service['snmpd']
@@ -361,7 +361,7 @@ class snmp (
     owner   => 'root',
     group   => 'root',
     path    => $snmp::params::sysconfig,
-    content => template("snmp/snmpd.sysconfig-${::osfamily}.erb"),
+    content => template("snmp/snmpd.sysconfig-${snmp::params::osfamily}.erb"),
     require => Package['snmpd'],
     notify  => Service['snmpd'],
   }
@@ -377,14 +377,14 @@ class snmp (
     notify  => $snmptrapd_conf_notify,
   }
 
-  if $::osfamily == 'RedHat' {
+  if $snmp::params::osfamily == 'RedHat' {
     file { 'snmptrapd.sysconfig':
       ensure  => $file_ensure,
       mode    => '0644',
       owner   => 'root',
       group   => 'root',
       path    => $snmp::params::trap_sysconfig,
-      content => template("snmp/snmptrapd.sysconfig-${::osfamily}.erb"),
+      content => template("snmp/snmptrapd.sysconfig-${snmp::params::osfamily}.erb"),
       require => Package['snmpd'],
       notify  => Service['snmptrapd'],
     }
@@ -397,7 +397,7 @@ class snmp (
       hasrestart => $trap_service_hasrestart,
       require    => [ Package['snmpd'], File['var-net-snmp'], ],
     }
-  } elsif $::osfamily == 'Suse' {
+  } elsif $snmp::params::osfamily == 'Suse' {
     exec { 'install /etc/init.d/snmptrapd':
       command => '/usr/bin/install -o 0 -g 0 -m0755 -p /usr/share/doc/packages/net-snmp/rc.snmptrapd /etc/init.d/snmptrapd',
       creates => '/etc/init.d/snmptrapd',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -215,7 +215,10 @@ class snmp::params {
     $safe_trap_service_hasrestart = $trap_service_hasrestart
   }
 
-  case $::osfamily {
+  if $::operatingsystem =~ /^(?i-mx:(SLES))$/ { $osfamily = 'Suse' }
+  else { $osfamily = $::osfamily }
+
+  case $osfamily {
     'RedHat': {
       $majdistrelease = regsubst($::operatingsystemrelease,'^(\d+)\.(\d+)','\1')
       case $::operatingsystem {


### PR DESCRIPTION
osfamily fact has no value on SLES 11 SP3 during my tests,
consequently SLES is not recognized as belonging to
the Suse osfamily. Then I added a test in params.pp to give a
value to $snmp::params::osfamily which is 'Suse' if $::operatingsystem
is 'SLES' or $::osfamily if not. I also changed calls for $::osfamily
to $snmp::params::osfamily. Maybe this problem is due to an inconsistent
reason or because my tests are made on virtual machines (??). For now
this does the trick for me.
