### PR TITLE
Custom VACM com2sec and group mappings.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,19 @@
 #   Location of the SNMP system.
 #   Default: Unknown
 #
+# [*com2sec*]
+#   An array of VACM com2sec mappings.
+#   Must provide SECNAME, SOURCE and COMMUNITY.
+#   See http://www.net-snmp.org/docs/man/snmpd.conf.html#lbAL for details.
+#   Default: [ "notConfigUser default ${ro_community}" ]
+#
+# [*groups*]
+#   An array of VACM group mappings.
+#   Must provide GROUP, {v1|v2c|usm|tsm|ksm}, SECNAME.
+#   See http://www.net-snmp.org/docs/man/snmpd.conf.html#lbAL for details.
+#   Default: [ 'notConfigGroup v1  notConfigUser',
+#              'notConfigGroup v2c notConfigUser' ]
+#
 # [*services*]
 #   For a host system, a good value is 72 (application + end-to-end layers).
 #   Default: 72
@@ -214,6 +227,8 @@ class snmp (
   $rw_network              = $snmp::params::rw_network,
   $contact                 = $snmp::params::contact,
   $location                = $snmp::params::location,
+  $com2sec                 = $snmp::params::com2sec,
+  $groups                  = $snmp::params::groups,
   $views                   = $snmp::params::views,
   $accesses                = $snmp::params::accesses,
   $dlmod                   = $snmp::params::dlmod,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,6 +56,21 @@ class snmp::params {
     default => $::snmp_location,
   }
 
+  $com2sec = $::snmp_com2sec ? {
+    undef   => [
+      "notConfigUser  default       ${ro_community}",
+    ],
+    default => $::snmp_com2sec,
+  }
+
+  $groups = $::snmp_groups ? {
+    undef   => [
+      'notConfigGroup v1            notConfigUser',
+      'notConfigGroup v2c           notConfigUser',
+    ],
+    default => $::snmp_groups,
+  }
+
   $services = $::snmp_services ? {
     undef   => 72,
     default => $::snmp_services,

--- a/spec/classes/snmp_init_spec.rb
+++ b/spec/classes/snmp_init_spec.rb
@@ -471,6 +471,24 @@ describe 'snmp', :type => 'class' do
       end
     end
 
+    describe 'com2sec => [ SomeString ]' do
+      let(:params) {{ :com2sec => [ 'SomeString', ] }}
+      it 'should contain File[snmpd.conf] with contents "com2sec SomeString"' do
+        verify_contents(subject, 'snmpd.conf', [
+          'com2sec SomeString',
+        ])
+      end
+    end
+
+    describe 'groups => [ SomeString ]' do
+      let(:params) {{ :groups => [ 'SomeString', ] }}
+      it 'should contain File[snmpd.conf] with contents "groups SomeString"' do
+        verify_contents(subject, 'snmpd.conf', [
+          'group   SomeString',
+        ])
+      end
+    end
+
     describe 'dlmod => [ SomeString ]' do
       let(:params) {{ :dlmod => [ 'SomeString', ] }}
       it 'should contain File[snmpd.conf] with contents "dlmod SomeString"' do

--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -22,11 +22,18 @@ agentaddress <%= @agentaddress.join(',') %>
 # ------------------------------------------------------------------------------
 # VACM Configuration
 #       sec.name       source        community
-com2sec notConfigUser  default       <%= @ro_community %>
+<% if @com2sec.any? -%>
+<% @com2sec.each do |com2sec| -%>
+com2sec <%= com2sec %>
+<% end -%>
+<% end -%>
 
 #       groupName      securityModel securityName
-group   notConfigGroup v1            notConfigUser
-group   notConfigGroup v2c           notConfigUser
+<% if @groups.any? -%>
+<% @groups.each do |group| -%>
+group   <%= group %>
+<% end -%>
+<% end -%>
 
 #       name          incl/excl  subtree             mask(optional)
 <% @views.each do |view| -%>


### PR DESCRIPTION
This feature adds support for overriding the 'com2sec' and 'group' mappings in snmpd.conf, in the same manner as for views, etc. The default behaviour remains the same and the additional parameters have been added to the spec.
