### PR TITLE
Lowercase variable names

### DIFF
--- a/manifests/snmpv3_user.pp
+++ b/manifests/snmpv3_user.pp
@@ -60,12 +60,12 @@ define snmp::snmpv3_user (
   $daemon   = 'snmpd'
 ) {
   # Validate our regular expressions
-  $Aoptions = [ '^SHA$', '^MD5$' ]
-  validate_re($authtype, $Aoptions, '$authtype must be either SHA or MD5.')
-  $Poptions = [ '^AES$', '^DES$' ]
-  validate_re($privtype, $Poptions, '$privtype must be either AES or DES.')
-  $Doptions = [ '^snmpd$', '^snmptrapd$' ]
-  validate_re($daemon, $Doptions, '$daemon must be either snmpd or snmptrapd.')
+  $hash_options = [ '^SHA$', '^MD5$' ]
+  validate_re($authtype, $hash_options, '$authtype must be either SHA or MD5.')
+  $enc_options = [ '^AES$', '^DES$' ]
+  validate_re($privtype, $enc_options, '$privtype must be either AES or DES.')
+  $daemon_options = [ '^snmpd$', '^snmptrapd$' ]
+  validate_re($daemon, $daemon_options, '$daemon must be either snmpd or snmptrapd.')
 
   include snmp
 


### PR DESCRIPTION
The Puppet syntax will not allow variable names containing capital letters anymore at the next major version  (https://docs.puppetlabs.com/puppet/latest/reference/experiments_future.html#capitalized-variable-names-not-allowed). This already affects people like me who use `parser = future`. This patch renames the offending variables.
