### PR TITLE
Add engine id to snmpv3user

### DIFF
--- a/manifests/snmpv3_user.pp
+++ b/manifests/snmpv3_user.pp
@@ -8,6 +8,10 @@
 #   Name of the user.
 #   Required
 #
+# [*engineid*]
+#   ID of Engine Generating traps
+#   Optional
+#
 # [*authpass*]
 #   Authentication password for the user.
 #   Required
@@ -39,6 +43,7 @@
 # === Sample Usage:
 #
 #   snmp::snmpv3_user { 'myuser':
+#     engineid => '0x90d00d73c50c003BFFEC53'
 #     authtype => 'MD5',
 #     authpass => '1234auth',
 #     privpass => '5678priv',
@@ -54,6 +59,7 @@
 #
 define snmp::snmpv3_user (
   $authpass,
+  $engineid,
   $authtype = 'SHA',
   $privpass = undef,
   $privtype = 'AES',
@@ -76,11 +82,17 @@ define snmp::snmpv3_user (
     $service_name   = 'snmpd'
     $service_before = Service['snmpd']
   }
-
-  if $privpass {
-    $cmd = "createUser ${title} ${authtype} \\\"${authpass}\\\" ${privtype} \\\"${privpass}\\\""
+  
+  if $engineid {
+    $engineparam = "-e ${engineid}"
   } else {
-    $cmd = "createUser ${title} ${authtype} \\\"${authpass}\\\""
+    $engineparam = ""
+  }
+  
+  if $privpass {
+    $cmd = "createUser ${engineid} ${title} ${authtype} \\\"${authpass}\\\" ${privtype} \\\"${privpass}\\\""
+  } else {
+    $cmd = "createUser ${engineid} ${title} ${authtype} \\\"${authpass}\\\""
   }
   exec { "create-snmpv3-user-${title}":
     path    => '/bin:/sbin:/usr/bin:/usr/sbin',

--- a/spec/defines/snmp_snmpv3_user_spec.rb
+++ b/spec/defines/snmp_snmpv3_user_spec.rb
@@ -109,12 +109,13 @@ describe 'snmp::snmpv3_user', :type => 'define' do
 
       let :params do {
         :authpass => 'myauthpass',
+        :engineid => '0x4432046378719066780391',
         :daemon   => 'snmptrapd',
       }
       end
 
       it { should contain_exec('create-snmpv3-user-myTRAPuser').with(
-        :command => 'service snmptrapd stop ; sleep 5 ; echo "createUser myTRAPuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmptrapd.conf && touch /var/lib/net-snmp/myTRAPuser-snmptrapd',
+        :command => 'service snmptrapd stop ; sleep 5 ; echo "createUser -e 0x4432046378719066780391 myTRAPuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmptrapd.conf && touch /var/lib/net-snmp/myTRAPuser-snmptrapd',
         :creates => '/var/lib/net-snmp/myTRAPuser-snmptrapd',
         :require => [ 'Package[snmpd]', 'File[var-net-snmp]' ],
         :before  => 'Service[snmptrapd]'
@@ -170,12 +171,13 @@ describe 'snmp::snmpv3_user', :type => 'define' do
 
       let :params do {
         :authpass => 'myauthpass',
+        :engineid => '0x4432046378719066780391',
         :daemon   => 'snmptrapd',
       }
       end
 
       it { should contain_exec('create-snmpv3-user-myTRAPuser').with(
-        :command => 'service snmpd stop ; sleep 5 ; echo "createUser myTRAPuser SHA \"myauthpass\"" >>/var/lib/snmp/snmptrapd.conf && touch /var/lib/snmp/myTRAPuser-snmptrapd',
+        :command => 'service snmpd stop ; sleep 5 ; echo "createUser -e 0x4432046378719066780391 myTRAPuser SHA \"myauthpass\"" >>/var/lib/snmp/snmptrapd.conf && touch /var/lib/snmp/myTRAPuser-snmptrapd',
         :creates => '/var/lib/snmp/myTRAPuser-snmptrapd',
         :require => [ 'Package[snmpd]', 'File[var-net-snmp]' ],
         :before  => 'Service[snmpd]'
@@ -231,12 +233,13 @@ describe 'snmp::snmpv3_user', :type => 'define' do
 
       let :params do {
         :authpass => 'myauthpass',
+        :engineid => '0x4432046378719066780391',
         :daemon   => 'snmptrapd',
       }
       end
 
       it { should contain_exec('create-snmpv3-user-myTRAPuser').with(
-        :command => 'service snmptrapd stop ; sleep 5 ; echo "createUser myTRAPuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmptrapd.conf && touch /var/lib/net-snmp/myTRAPuser-snmptrapd',
+        :command => 'service snmptrapd stop ; sleep 5 ; echo "createUser -e 0x4432046378719066780391 myTRAPuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmptrapd.conf && touch /var/lib/net-snmp/myTRAPuser-snmptrapd',
         :creates => '/var/lib/net-snmp/myTRAPuser-snmptrapd',
         :require => [ 'Package[snmpd]', 'File[var-net-snmp]' ],
         :before  => 'Service[snmptrapd]'


### PR DESCRIPTION
Open to critiques here; willing to make changes or see changes made to get this integrated.

Had to pull my snmpv3 trap user configs out because traps were not getting received without the engine ID's being part of the createUser statement.