### PR TITLE
Making things work a little better on Debian 7 and 9

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -583,11 +583,11 @@ class snmp (
     }
   }
 
-  if $systemctl_path != "" {
+  if $systemctl_path != '' {
     exec { "${systemctl_path} daemon-reload":
       refreshonly => true,
-      subscribe => File["snmpd.sysconfig"],
-      notify  => Service['snmpd'],
+      subscribe   => File['snmpd.sysconfig'],
+      notify      => Service['snmpd'],
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -353,6 +353,7 @@ class snmp (
   $agentx_socket                = $snmp::params::agentx_socket,
   $agentx_timeout               = $snmp::params::agentx_timeout,
   $agentx_retries               = $snmp::params::agentx_retries,
+  $systemctl_path               = $snmp::params::systemctl_path,
 ) inherits snmp::params {
   # Validate our booleans
   validate_bool($master)
@@ -383,6 +384,7 @@ class snmp (
   validate_string($template_snmpd_sysconfig)
   validate_string($template_snmptrapd)
   validate_string($template_snmptrapd_sysconfig)
+  validate_string($systemctl_path)
 
   # Validate our numbers
   validate_numeric($agentx_retries)
@@ -578,6 +580,14 @@ class snmp (
         Package['snmpd'],
         File['var-net-snmp'],
       ],
+    }
+  }
+
+  if $systemctl_path != "" {
+    exec { "${systemctl_path} daemon-reload":
+      refreshonly => true,
+      subscribe => File["snmpd.sysconfig"],
+      notify  => Service['snmpd'],
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -583,7 +583,7 @@ class snmp (
     }
   }
 
-  if $systemctl_path != '' {
+  if $systemctl_path {
     exec { "${systemctl_path} daemon-reload":
       refreshonly => true,
       subscribe   => File['snmpd.sysconfig'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -418,7 +418,7 @@ class snmp::params {
       } else {
         $majdistrelease = regsubst($::operatingsystemrelease,'^(\d+)\.(\d+)','\1')
       }
-      $systemctl_path         = ""
+      $systemctl_path         = ''
       case $::operatingsystem {
         'Fedora': {
           $snmpd_options        = '-LS0-6d'
@@ -476,15 +476,15 @@ class snmp::params {
         $varnetsnmp_owner       = 'Debian-snmp'
         $varnetsnmp_group       = 'Debian-snmp'
         $sysconfig              = '/lib/systemd/system/snmpd.service'
-	#These options are used in debian package 5.7.3+dfsg-1.7 except the -Lsd => -LS6d fix from debian bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=684721
+        #These options are used in debian package 5.7.3+dfsg-1.7 except the -Lsd => -LS6d fix from debian bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=684721
         $snmpd_options          = "-LS6d -Lf /dev/null -u ${varnetsnmp_owner} -g ${varnetsnmp_group} -I -smux,mteTrigger,mteTriggerConf -f"
-	$systemctl_path         = "/bin/systemctl"
+        $systemctl_path         = "/bin/systemctl"
       } else {
         $varnetsnmp_owner       = 'snmp'
         $varnetsnmp_group       = 'snmp'
         $sysconfig              = '/etc/default/snmpd'
         $snmpd_options          = "-LS6d -Lf /dev/null -u ${varnetsnmp_owner} -g ${varnetsnmp_group} -I -smux -p /var/run/snmpd.pid"
-	$systemctl_path         = ""
+        $systemctl_path         = ''
       }
       $package_name             = 'snmpd'
       $service_config           = '/etc/snmp/snmpd.conf'
@@ -520,7 +520,7 @@ class snmp::params {
       $trap_service_config      = '/etc/snmp/snmptrapd.conf'
       $trap_service_name        = 'snmptrapd'
       $snmptrapd_options        = undef
-      $systemctl_path           = ""
+      $systemctl_path           = ''
     }
     'FreeBSD': {
       $package_name             = 'net-mgmt/net-snmp'
@@ -543,7 +543,7 @@ class snmp::params {
       $trap_service_config      = '/usr/local/etc/snmp/snmptrapd.conf'
       $trap_service_name        = 'snmptrapd'
       $snmptrapd_options        = undef
-      $systemctl_path           = ""
+      $systemctl_path           = ''
     }
     'OpenBSD': {
       $package_name             = 'net-snmp'
@@ -566,7 +566,7 @@ class snmp::params {
       $trap_service_config      = '/etc/snmp/snmptrapd.conf'
       $trap_service_name        = 'netsnmptrapd'
       $snmptrapd_options        = undef
-      $systemctl_path           = ""
+      $systemctl_path           = ''
     }
     default: {
       fail("Module ${::module} is not supported on ${::operatingsystem}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -418,7 +418,7 @@ class snmp::params {
       } else {
         $majdistrelease = regsubst($::operatingsystemrelease,'^(\d+)\.(\d+)','\1')
       }
-      $systemctl_path         = ''
+      $systemctl_path         = undef
       case $::operatingsystem {
         'Fedora': {
           $snmpd_options        = '-LS0-6d'
@@ -478,13 +478,13 @@ class snmp::params {
         $sysconfig              = '/lib/systemd/system/snmpd.service'
         #These options are used in debian package 5.7.3+dfsg-1.7 except the -Lsd => -LS6d fix from debian bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=684721
         $snmpd_options          = "-LS6d -Lf /dev/null -u ${varnetsnmp_owner} -g ${varnetsnmp_group} -I -smux,mteTrigger,mteTriggerConf -f"
-        $systemctl_path         = "/bin/systemctl"
+        $systemctl_path         = '/bin/systemctl'
       } else {
         $varnetsnmp_owner       = 'snmp'
         $varnetsnmp_group       = 'snmp'
         $sysconfig              = '/etc/default/snmpd'
         $snmpd_options          = "-LS6d -Lf /dev/null -u ${varnetsnmp_owner} -g ${varnetsnmp_group} -I -smux -p /var/run/snmpd.pid"
-        $systemctl_path         = ''
+        $systemctl_path         = undef
       }
       $package_name             = 'snmpd'
       $service_config           = '/etc/snmp/snmpd.conf'
@@ -520,7 +520,7 @@ class snmp::params {
       $trap_service_config      = '/etc/snmp/snmptrapd.conf'
       $trap_service_name        = 'snmptrapd'
       $snmptrapd_options        = undef
-      $systemctl_path           = ''
+      $systemctl_path           = undef
     }
     'FreeBSD': {
       $package_name             = 'net-mgmt/net-snmp'
@@ -543,7 +543,7 @@ class snmp::params {
       $trap_service_config      = '/usr/local/etc/snmp/snmptrapd.conf'
       $trap_service_name        = 'snmptrapd'
       $snmptrapd_options        = undef
-      $systemctl_path           = ''
+      $systemctl_path           = undef
     }
     'OpenBSD': {
       $package_name             = 'net-snmp'
@@ -566,7 +566,7 @@ class snmp::params {
       $trap_service_config      = '/etc/snmp/snmptrapd.conf'
       $trap_service_name        = 'netsnmptrapd'
       $snmptrapd_options        = undef
-      $systemctl_path           = ''
+      $systemctl_path           = undef
     }
     default: {
       fail("Module ${::module} is not supported on ${::operatingsystem}")

--- a/templates/snmpd.sysconfig-Debian.erb
+++ b/templates/snmpd.sysconfig-Debian.erb
@@ -1,4 +1,4 @@
-<%- if @systemctl_path != "" then -%>
+<%- if @systemctl_path then -%>
 [Unit]
 Description=Simple Network Management Protocol (SNMP) Daemon.
 After=network.target

--- a/templates/snmpd.sysconfig-Debian.erb
+++ b/templates/snmpd.sysconfig-Debian.erb
@@ -1,3 +1,21 @@
+<%- if @systemctl_path != "" then -%>
+[Unit]
+Description=Simple Network Management Protocol (SNMP) Daemon.
+After=network.target
+ConditionPathExists=/etc/snmp/snmpd.conf
+
+[Service]
+Environment="MIBSDIR=/usr/share/snmp/mibs:/usr/share/snmp/mibs/iana:/usr/share/snmp/mibs/ietf:/usr/share/mibs/site:/usr/share/snmp/mibs:/usr/share/mibs/iana:/usr/share/mibs/ietf:/usr/share/mibs/netsnmp"
+Environment="MIBS="
+Type=simple
+ExecStartPre=/bin/mkdir -p /var/run/agentx
+ExecStart=/usr/sbin/snmpd <%= @snmpd_options %>
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target
+
+<% else -%>
 ###
 ### File managed by Puppet
 ###
@@ -23,3 +41,5 @@ TRAPDOPTS='<%= @snmptrapd_options %>'
 
 # create symlink on Debian legacy location to official RFC path
 SNMPDCOMPAT=yes
+<% end -%>
+


### PR DESCRIPTION
The current Debian stable package is using systemd, so /etc/default/snmpd was ignored. I've made some changes for rudimentry systemd support on Debian only.

In the process I realised that snmpd trap has probably not worked under Debian for a while (Debian moved it into snmptrapd). I can't see how to add it without messing with the code more extensively.

The systemd code also ignores @snmpdrun - it doesn't seem that /lib/systemd/system/snmpd.service has an appropriate place to put it.

On old versions of Debian this module also now failed due to not having $::operatingsystemmajrelease defined

Otherwise it does seem that this patch will install snmpd correctly on Debian 7.1 through to 9.3