### PR TITLE
Configure owner of files in Ubuntu Bionic

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -473,6 +473,9 @@ class snmp::params {
       if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease >= '9' {
         $varnetsnmp_owner = 'Debian-snmp'
         $varnetsnmp_group = 'Debian-snmp'
+      } elsif $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemmajrelease, '18.04') >= 0 {
+        $varnetsnmp_owner = 'Debian-snmp'
+        $varnetsnmp_group = 'Debian-snmp'
       } else {
         $varnetsnmp_owner       = 'snmp'
         $varnetsnmp_group       = 'snmp'


### PR DESCRIPTION
In Ubuntu 18.04 _/var/lib/snmp_ is owned by user `Debian-snmp` and group `Debian-snmp` instead of `snmp:snmp` used in former releases.