### PR TITLE
Disable snmpv2

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -260,7 +260,7 @@
 # [*snmpv2_enable*]
 #   Disable com2sec, group, and access in snmpd.conf
 #  
-#   Default: false
+#   Default: true
 #
 # === Actions:
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -353,6 +353,7 @@ class snmp (
   $agentx_socket                = $snmp::params::agentx_socket,
   $agentx_timeout               = $snmp::params::agentx_timeout,
   $agentx_retries               = $snmp::params::agentx_retries,
+  $snmpv2_enable                = $snmp::params::snmpv2_enable
 ) inherits snmp::params {
   # Validate our booleans
   validate_bool($master)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -353,7 +353,7 @@ class snmp (
   $agentx_socket                = $snmp::params::agentx_socket,
   $agentx_timeout               = $snmp::params::agentx_timeout,
   $agentx_retries               = $snmp::params::agentx_retries,
-  $snmpv2_enable                = $snmp::params::snmpv2_enable
+  $snmpv2_enable                = $snmp::params::snmpv2_enable,
 ) inherits snmp::params {
   # Validate our booleans
   validate_bool($master)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -257,6 +257,11 @@
 #   Defines the number of retries for an AgentX request.
 #   Default: 5
 #
+# [*snmpv2_enable*]
+#   Disable com2sec, group, and access in snmpd.conf
+#  
+#   Default: false
+#
 # === Actions:
 #
 # Installs the Net-SNMP daemon package, service, and configuration.
@@ -363,6 +368,7 @@ class snmp (
   validate_bool($service_hasstatus)
   validate_bool($service_hasrestart)
   validate_bool($openmanage_enable)
+  validate_bool($snmpv2_enable)
 
   # Validate our arrays
   validate_array($snmptrapdaddr)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -410,7 +410,7 @@ class snmp::params {
   } else {
     $snmpv2_enable =  true
   }
-  
+ 
   $template_snmpd_conf = 'snmp/snmpd.conf.erb'
   $template_snmpd_sysconfig = "snmp/snmpd.sysconfig-${::osfamily}.erb"
   $template_snmptrapd = 'snmp/snmptrapd.conf.erb'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -410,7 +410,7 @@ class snmp::params {
   } else {
     $snmpv2_enable =  true
   }
- 
+
   $template_snmpd_conf = 'snmp/snmpd.conf.erb'
   $template_snmpd_sysconfig = "snmp/snmpd.sysconfig-${::osfamily}.erb"
   $template_snmptrapd = 'snmp/snmptrapd.conf.erb'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -404,6 +404,13 @@ class snmp::params {
     $safe_trap_service_hasrestart = $trap_service_hasrestart
   }
 
+  $snmp_snmpv2_enable = getvar('::snmpv2_enable')
+  if $snmp_openmanage_enable {
+    $snmpv2_enable =  $snmp_snmpv2_enable
+  } else {
+    $snmpv2_enable =  true
+  }
+  
   $template_snmpd_conf = 'snmp/snmpd.conf.erb'
   $template_snmpd_sysconfig = "snmp/snmpd.sysconfig-${::osfamily}.erb"
   $template_snmptrapd = 'snmp/snmptrapd.conf.erb'

--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -74,17 +74,15 @@ com2sec6 <%= c %>
 group   <%= group %>
 <% end -%>
 
-#       name          incl/excl  subtree             mask(optional)
-<% @views.each do |view| -%>
-view    <%= view %>
-<% end -%>
-
 #       group          context sec.model sec.level prefix read       write notif
 <% @accesses.each do |access| -%>
 access  <%= access %>
 <% end -%>
 <% end -%>
-
+#       name          incl/excl  subtree             mask(optional)
+<% @views.each do |view| -%>
+view    <%= view %>
+<% end -%>
 # ------------------------------------------------------------------------------
 # Typed-View Configuration
 

--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -60,6 +60,7 @@ rocommunity6 <%= c %> <%= n %>
 # ------------------------------------------------------------------------------
 # VACM Configuration
 #       sec.name       source        community
+<% if @snmpv2_enable -%>
 <% @com2sec.each do |c| -%>
 com2sec <%= c %>
 <% end -%>
@@ -81,6 +82,7 @@ view    <%= view %>
 #       group          context sec.model sec.level prefix read       write notif
 <% @accesses.each do |access| -%>
 access  <%= access %>
+<% end -%>
 <% end -%>
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Hello,

Here is a small PR which create a new variable snmpv2_enable, by default this variable is at true, so there is no change from current behaviour.

If set to false, this remove com2sec, group, and access config in snmpd.conf and there is no error in the log when restarting the daemon.