### PR TITLE
Add ubuntu 18.04 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -142,6 +142,9 @@ class snmp::params {
       if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '9') >= 0 {
         $varnetsnmp_owner = 'Debian-snmp'
         $varnetsnmp_group = 'Debian-snmp'
+      } elsif $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemmajrelease, '18.04') >= 0 {
+        $varnetsnmp_owner = 'Debian-snmp'
+        $varnetsnmp_group = 'Debian-snmp'
       } else {
         $varnetsnmp_owner       = 'snmp'
         $varnetsnmp_group       = 'snmp'

--- a/metadata.json
+++ b/metadata.json
@@ -66,7 +66,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     }
   ],


### PR DESCRIPTION
Under Ubuntu 18.04 it appears the SNMP user and group have changed.
```
Error: Could not find user snmp
Error: /Stage[main]/Snmp/File[var-net-snmp]/owner: change from 'Debian-snmp' to 'snmp' failed: Could not find user snmp
Error: Could not find group snmp
Error: /Stage[main]/Snmp/File[var-net-snmp]/group: change from 'Debian-snmp' to 'snmp' failed: Could not find group snmp
Notice: /Stage[main]/Snmp/Service[snmpd]: Dependency File[var-net-snmp] has failures: true
Warning: /Stage[main]/Snmp/Service[snmpd]: Skipping because of failed dependencies
```

This request simply adds a condition to set the user and group correctly in params.pp