### PR TITLE
Debian systemd/sysvinit big rewrite: Request for (initial) comments

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,4 @@
 fixtures:
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    systemd: 'https://github.com/camptocamp/puppet-systemd.git'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,8 +75,12 @@ class snmp::params {
   $snmpv2_enable = true
   $template_snmpd_conf = 'snmp/snmpd.conf.erb'
   $template_snmpd_sysconfig = "snmp/snmpd.sysconfig-${::osfamily}.erb"
+  $template_snmpd_systemd_override   = 'snmp/snmpd.systemd_override.erb'
   $template_snmptrapd = 'snmp/snmptrapd.conf.erb'
   $template_snmptrapd_sysconfig = "snmp/snmptrapd.sysconfig-${::osfamily}.erb"
+  $template_snmptrapd_systemd_override = 'snmp/snmptrapd.systemd_override.erb'
+
+
 
   case $::osfamily {
     'RedHat': {
@@ -125,6 +129,7 @@ class snmp::params {
           }
         }
       }
+      $snmptrapd_package_name   = undef
       $package_name             = 'net-snmp'
       $service_config           = '/etc/snmp/snmpd.conf'
       $service_config_dir_group = 'root'
@@ -146,16 +151,26 @@ class snmp::params {
         $varnetsnmp_owner = 'Debian-snmp'
         $varnetsnmp_group = 'Debian-snmp'
       } else {
-        $varnetsnmp_owner       = 'snmp'
-        $varnetsnmp_group       = 'snmp'
+        $varnetsnmp_owner = 'snmp'
+        $varnetsnmp_group = 'snmp'
       }
+
+      if $::facts['service_provider'] == 'systemd' {
+        $sysconfig      = undef
+        $trap_sysconfig = undef
+      } else {
+        $sysconfig      = '/etc/default/snmpd'
+        $trap_sysconfig = '/etc/default/snmptrapd'
+      }
+
       $package_name             = 'snmpd'
+      $snmptrapd_package_name   = 'snmptrapd'
       $service_config           = '/etc/snmp/snmpd.conf'
       $service_config_perms     = '0600'
       $service_config_dir_group = 'root'
       $service_name             = 'snmpd'
       $snmpd_options            = "-Lsd -Lf /dev/null -u ${varnetsnmp_owner} -g ${varnetsnmp_group} -I -smux -p /var/run/snmpd.pid"
-      $sysconfig                = '/etc/default/snmpd'
+      $snmptrapd_options        = '-Lsd -p /var/run/snmptrapd.pid'
       $var_net_snmp             = '/var/lib/snmp'
       $varnetsnmp_perms         = '0755'
 
@@ -163,17 +178,18 @@ class snmp::params {
       $client_config            = '/etc/snmp/snmp.conf'
 
       $trap_service_config      = '/etc/snmp/snmptrapd.conf'
-      $trap_service_name        = undef
-      $snmptrapd_options        = '-Lsd -p /var/run/snmptrapd.pid'
+      $trap_service_name        = 'snmptrapd'
     }
     'Suse': {
       $package_name             = 'net-snmp'
+      $snmptrapd_package_name   = undef
       $service_config           = '/etc/snmp/snmpd.conf'
       $service_config_perms     = '0600'
       $service_config_dir_group = 'root'
       $service_name             = 'snmpd'
       $snmpd_options            = 'd'
       $sysconfig                = '/etc/sysconfig/net-snmp'
+      $trap_sysconfig           = undef
       $var_net_snmp             = '/var/lib/net-snmp'
       $varnetsnmp_perms         = '0755'
       $varnetsnmp_owner         = 'root'
@@ -188,6 +204,7 @@ class snmp::params {
     }
     'FreeBSD': {
       $package_name             = 'net-mgmt/net-snmp'
+      $snmptrapd_package_name   = undef
       $service_config_dir_path  = '/usr/local/etc/snmp'
       $service_config_dir_perms = '0755'
       $service_config_dir_owner = 'root'
@@ -206,10 +223,13 @@ class snmp::params {
 
       $trap_service_config      = '/usr/local/etc/snmp/snmptrapd.conf'
       $trap_service_name        = 'snmptrapd'
+      $sysconfig                = undef
+      $trap_sysconfig           = undef
       $snmptrapd_options        = undef
     }
     'OpenBSD': {
       $package_name             = 'net-snmp'
+      $snmptrapd_package_name   = undef
       $service_config_dir_path  = '/etc/snmp'
       $service_config_dir_perms = '0755'
       $service_config_dir_owner = 'root'
@@ -228,6 +248,8 @@ class snmp::params {
 
       $trap_service_config      = '/etc/snmp/snmptrapd.conf'
       $trap_service_name        = 'netsnmptrapd'
+      $sysconfig                = undef
+      $trap_sysconfig           = undef
       $snmptrapd_options        = undef
     }
     default: {

--- a/metadata.json
+++ b/metadata.json
@@ -10,6 +10,10 @@
   "tags": [ "snmp", "net-snmp", "monitoring" ],
   "dependencies": [
     {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 1.0.0 < 3.0.0"
+    },
+    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 6.0.0"
     }

--- a/spec/acceptance/nodesets/docker-debian-9-systemd.yml
+++ b/spec/acceptance/nodesets/docker-debian-9-systemd.yml
@@ -1,0 +1,16 @@
+---
+HOSTS:
+  debian-9-x64:
+    platform: debian-9-amd64
+    hypervisor: docker
+    image: debian:stretch
+    docker_preserve_image: true
+    docker_cmd: '["/lib/systemd/systemd"]'
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y systemd cron net-tools wget locales strace lsof && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
+      - 'rm -rf /usr/sbin/policy-rc.d'
+      - 'systemctl mask -- tmp.mount etc-hostname.mount etc-hosts.mount  etc-resolv.conf.mount -.mount swap.target dev-mqueue.mount cgproxy.service getty@tty1.service getty-static.service systemd-udev-trigger.service systemd-tmpfiles-setup-dev.service systemd-remount-fs.service systemd-ask-password-wall.path systemd-logind.service && systemctl set-default multi-user.target || true'
+
+CONFIG:
+  trace_limit: 200
+  type: aio

--- a/spec/acceptance/nodesets/docker-debian-9-sysvinit.yml
+++ b/spec/acceptance/nodesets/docker-debian-9-sysvinit.yml
@@ -1,0 +1,32 @@
+---
+HOSTS:
+  debian-9-x64:
+    platform: debian-9-amd64
+    hypervisor: docker
+    image: debian:stretch
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y sysvinit-core cron psmisc procps net-tools wget locales strace lsof && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
+      - 'apt-get remove -y --purge --auto-remove systemd'
+      - 'update-rc.d -f hwclock.sh remove || true'
+      - 'update-rc.d -f mountall-bootclean.sh remove || true'
+      - 'update-rc.d -f mountall.sh remove || true'
+      - 'update-rc.d -f checkfs.sh remove || true'
+      - 'update-rc.d -f checkroot.sh remove || true'
+      - 'update-rc.d -f motd remove || true'
+      - 'update-rc.d -f bootlogs remove || true'
+      - 'update-rc.d -f mountdevsubfs.sh remove || true'
+      - 'update-rc.d -f procps remove || true'
+      - 'update-rc.d -f hostname.sh remove || true'
+      - 'update-rc.d -f mountkernfs.sh remove || true'
+      - 'update-rc.d -f urandom remove || true'
+      - 'update-rc.d -f mountnfs-bootclean.sh remove || true'
+      - 'update-rc.d -f mountnfs.sh remove || true'
+      - 'update-rc.d -f umountnfs.sh remove || true'
+      - 'update-rc.d -f umountfs remove || true'
+      - 'update-rc.d -f umountroot remove || true'
+
+CONFIG:
+  trace_limit: 200
+  type: aio

--- a/spec/acceptance/snmpd_spec.rb
+++ b/spec/acceptance/snmpd_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper_acceptance'
+
+RSpec.describe 'snmpd' do
+  context 'defaults' do
+    manifest = <<-EOPP
+      class {'snmp': }
+    EOPP
+    it_behaves_like 'apply_manifest_twice', manifest
+    it_behaves_like 'has_process', manifest, 'snmpd'
+  end
+  context 'daemon options' do
+    manifest = <<-EOPP
+      class {'snmp':
+        snmpd_options => '-Lsd -Lf /dev/null -I -smux -a',
+      }
+    EOPP
+    it_behaves_like 'apply_manifest_twice', manifest
+    it_behaves_like 'has_process', manifest, 'snmpd', ['-Lsd','-Lf','/dev/null', '-a', '-I', '-smux']
+  end
+end

--- a/spec/acceptance/snmptrapd_spec.rb
+++ b/spec/acceptance/snmptrapd_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper_acceptance'
+
+RSpec.describe 'snmptrapd' do
+  context 'defaults' do
+    manifest = <<-EOPP
+      class {'snmp': trap_service_ensure => 'running', }
+    EOPP
+    it_behaves_like 'apply_manifest_twice', manifest
+    it_behaves_like 'has_process', manifest, 'snmptrapd'
+  end
+  context 'daemon options' do
+    manifest = <<-EOPP
+      class {'snmp':
+        trap_service_ensure => 'running',
+        snmptrapd_options => '-Ox -Lsd',
+      }
+    EOPP
+    it_behaves_like 'apply_manifest_twice', manifest
+    it_behaves_like 'has_process', manifest, 'snmptrapd', ['-Ox', '-Lsd']
+  end
+end

--- a/spec/acceptance/support/shared_examples_for_manifests.rb
+++ b/spec/acceptance/support/shared_examples_for_manifests.rb
@@ -1,0 +1,8 @@
+RSpec.shared_examples 'apply_manifest_twice' do |manifest|
+
+  it 'applies the manifest twice' do
+    apply_manifest(manifest, catch_failures: true)
+    apply_manifest(manifest, catch_changes: true)
+  end
+
+end

--- a/spec/acceptance/support/shared_examples_processes.rb
+++ b/spec/acceptance/support/shared_examples_processes.rb
@@ -1,0 +1,28 @@
+# Checks if a certain program/daemon is running and with which
+# arguments it has been launched.
+RSpec.shared_examples 'has_process' do |manifest, program, arguments|
+	context 'process is running' do
+		let(:process) { shell("/bin/ps -C #{program} -o comm=", accept_all_exit_codes: true).stdout.strip }
+		subject { process }
+		it "should be running #{program}" do
+      puts "process only check: '#{process}'"
+			is_expected.to eql(program)
+		end
+	end
+	unless arguments.nil? or arguments.size == 0
+		context 'process is running with arguments' do
+			let(:process) { shell("/bin/ps -C #{program} -o cmd=", accept_all_exit_codes: true).stdout.strip }
+			let(:args) do
+        process.split(' ')[1..-1]
+      end
+			subject { args }
+		  it "should be running #{program} with arguments #{arguments.inspect}" do
+        puts "process with args check: '#{process.inspect}' / #{args.inspect}"
+        is_expected.not_to be_empty
+		    arguments.each do |sample|
+          is_expected.to include(sample)
+        end
+			end
+		end
+	end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,26 @@
+require 'beaker-puppet'
+require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
+
+Dir["./spec/acceptance/support/**/*.rb"].sort.each { |f| require f }
+
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+configure_type_defaults_on(hosts)
+install_module_on(hosts)
+install_module_dependencies_on(hosts)
+
+RSpec.configure do |c|
+  c.formatter = :documentation
+
+  #hosts.each do |host|
+  #  case fact('os.family')
+  #  when 'Debian'
+  #    # nothing
+  #  when 'RedHat'
+  #    # Soft dep on epel for Passenger
+  #    #         install_package(host, 'epel-release')
+  #    #         end
+  #  end
+  #end
+end

--- a/templates/snmpd.sysconfig-Debian.erb
+++ b/templates/snmpd.sysconfig-Debian.erb
@@ -1,25 +1,15 @@
 ###
 ### File managed by Puppet
 ###
-# This file controls the activity of snmpd and snmptrapd
+# This file controls the activity of snmpd
 
 # Don't load any MIBs by default.
 # You might comment this lines once you have the MIBs downloaded.
 export MIBS=
 
 # snmpd control (yes means start daemon).
-SNMPDRUN=<%= @snmpdrun %>
+# This is hardcoded to yes so that puppet can manage the service properly.
+SNMPDRUN=yes
 
 # snmpd options (use syslog, close stdin/out/err).
 SNMPDOPTS='<%= @snmpd_options %>'
-
-# snmptrapd control (yes means start daemon).  As of net-snmp version
-# 5.0, master agentx support must be enabled in snmpd before snmptrapd
-# can be run.  See snmpd.conf(5) for how to do this.
-TRAPDRUN=<%= @trapdrun %>
-
-# snmptrapd options (use syslog).
-TRAPDOPTS='<%= @snmptrapd_options %>'
-
-# create symlink on Debian legacy location to official RFC path
-SNMPDCOMPAT=yes

--- a/templates/snmpd.systemd_override.erb
+++ b/templates/snmpd.systemd_override.erb
@@ -1,0 +1,10 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/snmpd <%= @snmpd_options %>
+<% if @snmpd_options.split(' ').include?('-f') -%>
+Type=
+Type=simple
+<% else -%>
+Type=
+Type=forking
+<% end -%>

--- a/templates/snmptrapd.sysconfig-Debian.erb
+++ b/templates/snmptrapd.sysconfig-Debian.erb
@@ -1,0 +1,14 @@
+###
+### File managed by Puppet
+###
+# This file controls the activity of snmptrapd
+
+# snmptrapd control (yes means start daemon).  As of net-snmp version
+# 5.0, master agentx support must be enabled in snmpd before snmptrapd
+# can be run.  See snmpd.conf(5) for how to do this.
+#
+# Hardcoded to yes so that we can use proper service management to enable/disable this using puppet
+TRAPDRUN=yes
+
+# snmptrapd options (use syslog).
+TRAPDOPTS='<%= @snmptrapd_options %>'

--- a/templates/snmptrapd.systemd_override.erb
+++ b/templates/snmptrapd.systemd_override.erb
@@ -1,0 +1,10 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/snmptrapd <%= @snmptrapd_options %>
+<% if @snmptrapd_options.split(' ').include?('-f') -%>
+Type=
+Type=simple
+<% else -%>
+Type=
+Type=forking
+<% end -%>


### PR DESCRIPTION
Branch name is not totally correct, but I started of with writing some (simple) beaker tests to double check my work.

I did a big rework of all the debian related logic:

* Support both systemd and sysvinit
* systemd: Use drop in files to override the systemd configuration
* sysvinit: all supported debian versions (?) currently have a split package and split sysconfig.
* Re-order debian related tests

I also made the capital mistake of reordering parameters.... 
