### PR TITLE
Implement snmpv3_user fact and snmp::snmpv3_usm_hash function

### DIFF
--- a/lib/facter/snmpv3_user.rb
+++ b/lib/facter/snmpv3_user.rb
@@ -1,0 +1,71 @@
+# snmpv3_user.rb --- Get SNMP usmUser data from configuration
+Facter.add(:snmpv3_user) do
+  confine :os do |os|
+    %w[Debian FreeBSD OpenBSD RedHat Suse].include? os['family']
+  end
+
+  setcode do
+    fact = {}
+
+    config = case Facter.value(:os)['family']
+             when 'Debian'  then '/var/lib/snmp/snmpd.conf'
+             when 'FreeBSD' then '/var/net-snmp/snmpd.conf'
+             when 'OpenBSD' then '/var/net-snmp/snmpd.conf'
+             when 'RedHat'  then '/var/lib/net-snmp/snmpd.conf'
+             when 'Suse'    then '/var/lib/net-snmp/snmpd.conf'
+             end
+
+    begin
+      File.readlines(config).each do |line|
+        next unless %r{^usmUser} =~ line
+
+        # split into items using whitespace delimiter
+        items = line.split
+
+        # need at least 11 items
+        next unless items.length >= 11
+
+        # extract user field and remove quotes
+        user = items[4].gsub(%r{\A['"]+|['"]+\Z}, '')
+
+        # convert hex string to ascii if necessary
+        # handle '0x' prefix and trailing NULL
+        user = [user[2..-1]].pack('H*').delete("\000") if %r{^0x} =~ user
+
+        # map OID to string for auth protocol
+        authproto = case items[7]
+                    when '.1.3.6.1.6.3.10.1.1.1' then 'usmNoAuthProtocol'
+                    when '.1.3.6.1.6.3.10.1.1.2' then 'usmHMACMD5AuthProtocol'
+                    when '.1.3.6.1.6.3.10.1.1.3' then 'usmHMACSHA1AuthProtocol'
+                    else 'usmUnknownAuthProtocol'
+                    end
+
+        authhash = items[8].gsub(%r{\A['"]+|['"]+\Z}, '')
+        authhash = '' if authhash == '0x'
+
+        # map OID to string for priv protocol
+        privproto = case items[9]
+                    when '.1.3.6.1.6.3.10.1.2.1' then 'usmNoPrivProtocol'
+                    when '.1.3.6.1.6.3.10.1.2.2' then 'usmDESPrivProtocol'
+                    when '.1.3.6.1.6.3.10.1.2.4' then 'usmAESPrivProtocol'
+                    else 'usmUnknownPrivProtocol'
+                    end
+
+        privhash = items[10].gsub(%r{\A['"]+|['"]+\Z}, '')
+        privhash = '' if privhash == '0x'
+
+        fact[user] = {
+          engine:    items[3],
+          authproto: authproto,
+          authhash:  authhash,
+          privproto: privproto,
+          privhash:  privhash
+        }
+      end
+    rescue
+      fact = {}
+    end
+
+    fact
+  end
+end

--- a/lib/puppet/functions/snmp/snmpv3_usm_hash.rb
+++ b/lib/puppet/functions/snmp/snmpv3_usm_hash.rb
@@ -1,0 +1,80 @@
+# snmpv3_usm_hash.rb --- Calculate SNMPv3 USM hash for a passphrase
+Puppet::Functions.create_function(:'snmp::snmpv3_usm_hash') do
+  # Calculate SNMPv3 USM hash for a passphrase
+  #
+  # The algorithm is implemented according to RFC-3414 sections A.2.1/A.2.2.
+  #
+  # @param authtype The authentication type to calculate. This must either be
+  # 'SHA' or 'MD5'.
+  #
+  # @param engine The SNMP engine used. The value is used as salt and must
+  # match the value used by the SNMP daemon.
+  #
+  # @param passphrase The passphrase for which the hash is calculated.
+  #
+  # @param bits The number of bits the result should be truncated to if it is
+  # longer. If the function is used to calculate the key for the privacy
+  # protocol it must be truncated to exactly 128 bits.
+  #
+  # @return [String] The calculated hash.
+  #
+  dispatch :snmpv3_usm_hash do
+    required_param 'String', :authtype
+    required_param 'String', :engine
+    required_param 'String', :passphrase
+    optional_param 'Integer', :bits
+    return_type 'String'
+  end
+
+  def snmpv3_usm_hash(authtype, engine, passphrase, bits = nil)
+    require 'digest'
+
+    unless passphrase.length >= 8
+      call_function('fail', 'passphrase chosen is below the length requirements (min=8)')
+    end
+
+    unless %w[SHA MD5].include? authtype
+      call_function('fail', "authtype must be either 'SHA' or 'MD5'")
+    end
+
+    # Create an instance of the selected digest
+    digest_instance = case authtype
+                      when 'SHA'
+                        Digest::SHA1.new
+                      when 'MD5'
+                        Digest::MD5.new
+                      end
+
+    # The hash will be calculated over exactly 1 megabyte filled using the
+    # passphrase. We do not actually create a buffer that large but instead
+    # use the incremental update functionality of the digest instance.
+    remaining_chars = 1_048_576 # 1024 * 1024
+
+    while remaining_chars > 0
+      if remaining_chars < passphrase.length
+        # Only the first couple of characters are needed to fill the megabyte
+        passphrase = passphrase.slice(0, remaining_chars)
+      end
+
+      # Update digest with the next part
+      digest_instance << passphrase
+
+      # Reduce remaining work by what we have done just now
+      remaining_chars -= passphrase.length
+    end
+
+    # Use engine as salt (remove leading '0x' if found)
+    salt = [engine.sub(%r{^0x}, '')].pack('H*')
+
+    # Calculate hash
+    hash = digest_instance.digest
+
+    hexdigest = digest_instance.hexdigest(hash + salt + hash)
+
+    # truncate string if requested (each hex char represents 4 bits)
+    hexdigest = hexdigest[0, bits / 4] unless bits.nil?
+
+    # Return digest as hexstring
+    '0x' << hexdigest
+  end
+end

--- a/manifests/snmpv3_user.pp
+++ b/manifests/snmpv3_user.pp
@@ -24,38 +24,54 @@
 #   Which daemon file in which to write the user.  snmpd or snmptrapd
 #
 define snmp::snmpv3_user (
-  $authpass,
-  Enum['SHA','MD5'] $authtype = 'SHA',
-
-  $privpass = undef,
-  Enum['AES','DES'] $privtype = 'AES',
-
-  Enum['snmpd','snmptrapd'] $daemon = 'snmpd'
+  String[8]                 $authpass,
+  Enum['SHA','MD5']         $authtype = 'SHA',
+  Optional[String[8]]       $privpass = undef,
+  Enum['AES','DES']         $privtype = 'AES',
+  Enum['snmpd','snmptrapd'] $daemon   = 'snmpd'
 ) {
   include snmp
 
   if ($daemon == 'snmptrapd') and ($facts['os']['family'] != 'Debian') {
     $service_name   = 'snmptrapd'
-    $service_before = Service['snmptrapd']
   } else {
     $service_name   = 'snmpd'
-    $service_before = Service['snmpd']
   }
 
-  if $privpass {
-    $cmd = "createUser ${title} ${authtype} \\\"${authpass}\\\" ${privtype} \\\"${privpass}\\\""
-  } else {
-    $cmd = "createUser ${title} ${authtype} \\\"${authpass}\\\""
+  $cmd = $privpass ? {
+    undef   => "createUser ${title} ${authtype} \\\"${authpass}\\\"",
+    default => "createUser ${title} ${authtype} \\\"${authpass}\\\" ${privtype} \\\"${privpass}\\\""
   }
-  exec { "create-snmpv3-user-${title}":
-    path    => '/bin:/sbin:/usr/bin:/usr/sbin',
-    # TODO: Add "rwuser ${title}" (or rouser) to /etc/snmp/${daemon}.conf
-    command => "service ${service_name} stop ; sleep 5 ; \
-echo \"${cmd}\" >>${snmp::params::var_net_snmp}/${daemon}.conf \
-&& touch ${snmp::params::var_net_snmp}/${title}-${daemon}",
-    creates => "${snmp::params::var_net_snmp}/${title}-${daemon}",
-    user    => 'root',
-    require => [ Package['snmpd'], File['var-net-snmp'], ],
-    before  => $service_before,
+
+  if ($title in $facts['snmpv3_user']) {
+    # user details from config are available as fact
+    $usm_user = $facts['snmpv3_user'][$title]
+
+    $authhash = snmp::snmpv3_usm_hash($authtype, $usm_user['engine'], $authpass)
+
+    # privacy protocol key may be empty; truncate to 128 bits if used
+    $privhash = empty($privpass) ? {
+      true    => '',
+      default => snmp::snmpv3_usm_hash($authtype, $usm_user['engine'], $privpass, 128)
+    }
+
+    # (re)create the user if at least one of the hashes is different
+    $create = ($authhash != $usm_user['authhash']) or ($privhash != $usm_user['privhash'])
+  }
+  else {
+    # user is unknown
+    $create = true
+  }
+
+  if $create {
+    exec { "create-snmpv3-user-${title}":
+      path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+      # TODO: Add "rwuser ${title}" (or rouser) to /etc/snmp/${daemon}.conf
+      command => "service ${service_name} stop ; sleep 5 ; \
+echo \"${cmd}\" >>${snmp::params::var_net_snmp}/${daemon}.conf",
+      user    => 'root',
+      require => [ Package['snmpd'], File['var-net-snmp'], ],
+      before  => Service[$service_name],
+    }
   }
 }

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,0 +1,22 @@
+# module specific facts used for unit tests
+---
+
+snmpv3_user:
+  md5user:
+    engine:    '0x000000000000000000000002'
+    authproto: 'usmHMACMD5AuthProtocol'
+    authhash:  '0x526f5eed9fcce26f8964c2930787d82b'
+    privproto: 'usmAESPrivProtocol'
+    privhash:  '0x526f5eed9fcce26f8964c2930787d82b'
+  shauser:
+    engine:    '0x000000000000000000000002'
+    authproto: 'usmHMACSHA1AuthProtocol'
+    authhash:  '0x6695febc9288e36282235fc7151f128497b38f3f'
+    privproto: 'usmAESPrivProtocol'
+    privhash:  '0x6695febc9288e36282235fc7151f1284'
+  nonuser:
+    engine:    '0x000000000000000000000002'
+    authproto: 'usmHMACSHA1AuthProtocol'
+    authhash:  '0x6695febc9288e36282235fc7151f128497b38f3f'
+    privproto: 'usmNoPrivProtocol'
+    privhash:  ''

--- a/spec/defines/snmp_snmpv3_user_spec.rb
+++ b/spec/defines/snmp_snmpv3_user_spec.rb
@@ -20,8 +20,7 @@ describe 'snmp::snmpv3_user' do
 
           it {
             is_expected.to contain_exec('create-snmpv3-user-myDEFAULTuser').with(
-              command: 'service snmpd stop ; sleep 5 ; echo "createUser myDEFAULTuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmpd.conf && touch /var/lib/net-snmp/myDEFAULTuser-snmpd',
-              creates: '/var/lib/net-snmp/myDEFAULTuser-snmpd'
+              command: 'service snmpd stop ; sleep 5 ; echo "createUser myDEFAULTuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmpd.conf'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]']).that_comes_before('Service[snmpd]')
           }
         end
@@ -40,8 +39,7 @@ describe 'snmp::snmpv3_user' do
 
           it {
             is_expected.to contain_exec('create-snmpv3-user-myALLuser').with(
-              command: 'service snmpd stop ; sleep 5 ; echo "createUser myALLuser MD5 \"myauthpass\" DES \"myprivpass\"" >>/var/lib/net-snmp/snmpd.conf && touch /var/lib/net-snmp/myALLuser-snmpd',
-              creates: '/var/lib/net-snmp/myALLuser-snmpd'
+              command: 'service snmpd stop ; sleep 5 ; echo "createUser myALLuser MD5 \"myauthpass\" DES \"myprivpass\"" >>/var/lib/net-snmp/snmpd.conf'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]']).that_comes_before('Service[snmpd]')
           }
         end
@@ -58,8 +56,7 @@ describe 'snmp::snmpv3_user' do
 
           it {
             is_expected.to contain_exec('create-snmpv3-user-myTRAPuser').with(
-              command: 'service snmptrapd stop ; sleep 5 ; echo "createUser myTRAPuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmptrapd.conf && touch /var/lib/net-snmp/myTRAPuser-snmptrapd',
-              creates: '/var/lib/net-snmp/myTRAPuser-snmptrapd'
+              command: 'service snmptrapd stop ; sleep 5 ; echo "createUser myTRAPuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmptrapd.conf'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]']).that_comes_before('Service[snmptrapd]')
           }
         end
@@ -75,8 +72,7 @@ describe 'snmp::snmpv3_user' do
 
           it {
             is_expected.to contain_exec('create-snmpv3-user-myDEFAULTuser').with(
-              command: 'service snmpd stop ; sleep 5 ; echo "createUser myDEFAULTuser SHA \"myauthpass\"" >>/var/lib/snmp/snmpd.conf && touch /var/lib/snmp/myDEFAULTuser-snmpd',
-              creates: '/var/lib/snmp/myDEFAULTuser-snmpd'
+              command: 'service snmpd stop ; sleep 5 ; echo "createUser myDEFAULTuser SHA \"myauthpass\"" >>/var/lib/snmp/snmpd.conf'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]']).that_comes_before('Service[snmpd]')
           }
         end
@@ -95,8 +91,7 @@ describe 'snmp::snmpv3_user' do
 
           it {
             is_expected.to contain_exec('create-snmpv3-user-myALLuser').with(
-              command: 'service snmpd stop ; sleep 5 ; echo "createUser myALLuser MD5 \"myauthpass\" DES \"myprivpass\"" >>/var/lib/snmp/snmpd.conf && touch /var/lib/snmp/myALLuser-snmpd',
-              creates: '/var/lib/snmp/myALLuser-snmpd'
+              command: 'service snmpd stop ; sleep 5 ; echo "createUser myALLuser MD5 \"myauthpass\" DES \"myprivpass\"" >>/var/lib/snmp/snmpd.conf'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]']).that_comes_before('Service[snmpd]')
           }
         end
@@ -113,8 +108,7 @@ describe 'snmp::snmpv3_user' do
 
           it {
             is_expected.to contain_exec('create-snmpv3-user-myTRAPuser').with(
-              command: 'service snmpd stop ; sleep 5 ; echo "createUser myTRAPuser SHA \"myauthpass\"" >>/var/lib/snmp/snmptrapd.conf && touch /var/lib/snmp/myTRAPuser-snmptrapd',
-              creates: '/var/lib/snmp/myTRAPuser-snmptrapd'
+              command: 'service snmpd stop ; sleep 5 ; echo "createUser myTRAPuser SHA \"myauthpass\"" >>/var/lib/snmp/snmptrapd.conf'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]']).that_comes_before('Service[snmpd]')
           }
         end
@@ -130,8 +124,7 @@ describe 'snmp::snmpv3_user' do
 
           it {
             is_expected.to contain_exec('create-snmpv3-user-myDEFAULTuser').with(
-              command: 'service snmpd stop ; sleep 5 ; echo "createUser myDEFAULTuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmpd.conf && touch /var/lib/net-snmp/myDEFAULTuser-snmpd',
-              creates: '/var/lib/net-snmp/myDEFAULTuser-snmpd'
+              command: 'service snmpd stop ; sleep 5 ; echo "createUser myDEFAULTuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmpd.conf'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]']).that_comes_before('Service[snmpd]')
           }
         end
@@ -150,8 +143,7 @@ describe 'snmp::snmpv3_user' do
 
           it {
             is_expected.to contain_exec('create-snmpv3-user-myALLuser').with(
-              command: 'service snmpd stop ; sleep 5 ; echo "createUser myALLuser MD5 \"myauthpass\" DES \"myprivpass\"" >>/var/lib/net-snmp/snmpd.conf && touch /var/lib/net-snmp/myALLuser-snmpd',
-              creates: '/var/lib/net-snmp/myALLuser-snmpd'
+              command: 'service snmpd stop ; sleep 5 ; echo "createUser myALLuser MD5 \"myauthpass\" DES \"myprivpass\"" >>/var/lib/net-snmp/snmpd.conf'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]']).that_comes_before('Service[snmpd]')
           }
         end
@@ -168,11 +160,193 @@ describe 'snmp::snmpv3_user' do
 
           it {
             is_expected.to contain_exec('create-snmpv3-user-myTRAPuser').with(
-              command: 'service snmptrapd stop ; sleep 5 ; echo "createUser myTRAPuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmptrapd.conf && touch /var/lib/net-snmp/myTRAPuser-snmptrapd',
-              creates: '/var/lib/net-snmp/myTRAPuser-snmptrapd'
+              command: 'service snmptrapd stop ; sleep 5 ; echo "createUser myTRAPuser SHA \"myauthpass\"" >>/var/lib/net-snmp/snmptrapd.conf'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]']).that_comes_before('Service[snmptrapd]')
           }
         end
+      end
+
+      describe 'with correct authpass and privpass for md5user' do
+        let(:title) { 'md5user' }
+
+        let :params do
+          {
+            authpass: 'maplesyrup',
+            authtype: 'MD5',
+            privpass: 'maplesyrup',
+            privtype: 'AES'
+          }
+        end
+
+        it {
+          is_expected.not_to contain_exec('create-snmpv3-user-md5user')
+        }
+      end
+
+      describe 'with correct authpass and wrong privpass for md5user' do
+        let(:title) { 'md5user' }
+
+        let :params do
+          {
+            authpass: 'maplesyrup',
+            authtype: 'MD5',
+            privpass: 'cornsyrup',
+            privtype: 'AES'
+          }
+        end
+
+        it {
+          is_expected.to contain_exec('create-snmpv3-user-md5user')
+        }
+      end
+
+      describe 'with wrong authpass and correct privpass for md5user' do
+        let(:title) { 'md5user' }
+
+        let :params do
+          {
+            authpass: 'cornsyrup',
+            authtype: 'MD5',
+            privpass: 'maplesyrup',
+            privtype: 'AES'
+          }
+        end
+
+        it {
+          is_expected.to contain_exec('create-snmpv3-user-md5user')
+        }
+      end
+
+      describe 'with wrong authpass and wrong privpass for md5user' do
+        let(:title) { 'md5user' }
+
+        let :params do
+          {
+            authpass: 'cornsyrup',
+            authtype: 'MD5',
+            privpass: 'cornsyrup',
+            privtype: 'AES'
+          }
+        end
+
+        it {
+          is_expected.to contain_exec('create-snmpv3-user-md5user')
+        }
+      end
+
+      describe 'with correct authpass and privpass for shauser' do
+        let(:title) { 'shauser' }
+
+        let :params do
+          {
+            authpass: 'maplesyrup',
+            authtype: 'SHA',
+            privpass: 'maplesyrup',
+            privtype: 'AES'
+          }
+        end
+
+        it {
+          is_expected.not_to contain_exec('create-snmpv3-user-shauser')
+        }
+      end
+
+      describe 'with correct authpass and wrong privpass for shauser' do
+        let(:title) { 'shauser' }
+
+        let :params do
+          {
+            authpass: 'maplesyrup',
+            authtype: 'SHA',
+            privpass: 'cornsyrup',
+            privtype: 'AES'
+          }
+        end
+
+        it {
+          is_expected.to contain_exec('create-snmpv3-user-shauser')
+        }
+      end
+
+      describe 'with wrong authpass and correct privpass for shauser' do
+        let(:title) { 'shauser' }
+
+        let :params do
+          {
+            authpass: 'cornsyrup',
+            authtype: 'SHA',
+            privpass: 'maplesyrup',
+            privtype: 'AES'
+          }
+        end
+
+        it {
+          is_expected.to contain_exec('create-snmpv3-user-shauser')
+        }
+      end
+
+      describe 'with wrong authpass and wrong privpass for shauser' do
+        let(:title) { 'shauser' }
+
+        let :params do
+          {
+            authpass: 'cornsyrup',
+            authtype: 'SHA',
+            privpass: 'cornsyrup',
+            privtype: 'AES'
+          }
+        end
+
+        it {
+          is_expected.to contain_exec('create-snmpv3-user-shauser')
+        }
+      end
+
+      describe 'with correct authpass and empty privpass for nonuser' do
+        let(:title) { 'nonuser' }
+
+        let :params do
+          {
+            authpass: 'maplesyrup',
+            authtype: 'SHA'
+          }
+        end
+
+        it {
+          is_expected.not_to contain_exec('create-snmpv3-user-nonuser')
+        }
+      end
+
+      describe 'with wrong authpass and empty privpass for nonuser' do
+        let(:title) { 'nonuser' }
+
+        let :params do
+          {
+            authpass: 'cornsyrup',
+            authtype: 'SHA'
+          }
+        end
+
+        it {
+          is_expected.to contain_exec('create-snmpv3-user-nonuser')
+        }
+      end
+
+      describe 'with correct authpass and defined privpass for nonuser' do
+        let(:title) { 'nonuser' }
+
+        let :params do
+          {
+            authpass: 'cornsyrup',
+            authtype: 'SHA',
+            privpass: 'cornsyrup',
+            privtype: 'AES'
+          }
+        end
+
+        it {
+          is_expected.to contain_exec('create-snmpv3-user-nonuser')
+        }
       end
     end
   end

--- a/spec/functions/snmpv3_usm_hash_spec.rb
+++ b/spec/functions/snmpv3_usm_hash_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'snmp::snmpv3_usm_hash' do
+  describe 'with MD5 hash (RFC-3414 A.3.1)' do
+    it {
+      is_expected.to run.with_params('MD5',
+                                     '0x000000000000000000000002',
+                                     'maplesyrup').
+        and_return('0x526f5eed9fcce26f8964c2930787d82b')
+    }
+  end
+
+  describe 'with SHA1 hash (RFC-3414 A.3.2)' do
+    it {
+      is_expected.to run.with_params('SHA',
+                                     '0x000000000000000000000002',
+                                     'maplesyrup').
+        and_return('0x6695febc9288e36282235fc7151f128497b38f3f')
+    }
+  end
+
+  describe 'with SHA1 hash and truncated to 128 bits' do
+    it {
+      is_expected.to run.with_params('SHA',
+                                     '0x000000000000000000000002',
+                                     'maplesyrup',
+                                     128).
+        and_return('0x6695febc9288e36282235fc7151f1284')
+    }
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

This PR contains the code for the new `snmpv3_user` fact and `snmp::snmpv3_usm_hash` function.

The fact is a structured fact that contains the configured SNMPv3 users and the the engine plus the passphrase hash that has been generated (e.g. by using `snmp::snmpv3_user`). Example:

```
snmpv3_user => {
  icinga => {
    engine => "0x80001f8880e0bd8a70cbf84f5800000000",
    authhash => "0x80001f8880e0bd8a70cbf84f5800000000"
  }
}
```
The function can be used to calculate the SHA1 or MD5 hashes for a given engine and passphrase. The generated hash can be compared with the value returned by the fact to determine if the user actually has the password that Puppet tries to enforce.

The function is a ruby version of the code published in RFC-3414 (sections A.2.1 and A.2.2).

With this fact and function the `snmp::snmpv3_user` defined type could be extended to actually check the existing user and trigger an update if the hashes do not match. Something like this has also been discussed in issue #4.

Maybe a custom type/provider implementation for `snmpv3_user` would be better. But I'm not sure how good restarting the SNMP daemon would fit into the type/provider model. 