### PR TITLE
Bug - Avoid puppet failures when optional variables are not set

### DIFF
--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -98,7 +98,7 @@ sysName <%= @sysname %>
 
 ################################################################################
 # EXTENDING AGENT FUNCTIONALITY
-<% if @extends.any? -%>
+<% if @extends -%>
 <% @extends.each do |extending| -%>
 extend <%= extending %>
 <% end -%>
@@ -132,6 +132,8 @@ smuxpeer .1.3.6.1.4.1.674.10892.1
 #Allow Systems Management Data Engine SNMP Storageservices to connect to snmpd using SMUX
 smuxpeer .1.3.6.1.4.1.674.10893.1
 <% end -%>
+<% if @snmpd_config -%>
 <% @snmpd_config.each do |line| -%>
 <%= line %>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
The any method causes puppet to fail on null values.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Catalog compilation fails when the server attempts to evaluate a template using the any? method.  Updated the snmpd.conf template to address this.