### PR TITLE
Bug - Update snmp::params to use proper fqdn fact

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -364,7 +364,7 @@ class snmp (
 
     # Make sure that if $trap_service_ensure == 'running' that
     # $service_ensure_real == 'running' on Debian.
-    if ($facts['os']['family'] == 'Debian') and ($trap_service_ensure_real == 'running') {
+    if ($facts['osfamily'] == 'Debian') and ($trap_service_ensure_real == 'running') {
       $service_ensure_real = $trap_service_ensure_real
       $service_enable_real = $trap_service_enable_real
     } else {
@@ -414,7 +414,7 @@ class snmp (
     require => Package['snmpd'],
   }
 
-  if $facts['os']['family'] == 'FreeBSD' {
+  if $facts['osfamily'] == 'FreeBSD' {
     file { $snmp::params::service_config_dir_path:
       ensure  => 'directory',
       mode    => $snmp::params::service_config_dir_perms,
@@ -424,7 +424,7 @@ class snmp (
     }
   }
 
-  if $facts['os']['family'] == 'Suse' {
+  if $facts['osfamily'] == 'Suse' {
     file { '/etc/init.d/snmptrapd':
       source  => '/usr/share/doc/packages/net-snmp/rc.snmptrapd',
       owner   => 'root',
@@ -457,7 +457,7 @@ class snmp (
   }
 
 
-  unless $facts['os']['family'] == 'FreeBSD' or $facts['os']['family'] == 'OpenBSD' {
+  unless $facts['osfamily'] == 'FreeBSD' or $facts['osfamily'] == 'OpenBSD' {
     file { 'snmpd.sysconfig':
       ensure  => $file_ensure,
       mode    => '0644',
@@ -470,7 +470,7 @@ class snmp (
     }
   }
 
-  if $facts['os']['family'] == 'RedHat' {
+  if $facts['osfamily'] == 'RedHat' {
     file { 'snmptrapd.sysconfig':
       ensure  => $file_ensure,
       mode    => '0644',
@@ -484,7 +484,7 @@ class snmp (
   }
 
   # Services
-  unless $facts['os']['family'] == 'Debian' {
+  unless $facts['osfamily'] == 'Debian' {
     service { 'snmptrapd':
       ensure     => $trap_service_ensure_real,
       name       => $trap_service_name,
@@ -506,7 +506,7 @@ class snmp (
     subscribe  => File['snmpd.conf'],
   }
 
-  if $facts['os']['family'] == 'Debian' {
+  if $facts['osfamily'] == 'Debian' {
     File['snmptrapd.conf'] ~> Service['snmpd']
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,7 @@ class snmp::params {
   $rw_network6 = '::1'
   $contact = 'Unknown'
   $location = 'Unknown'
-  $sysname = $facts['networking']['fqdn']
+  $sysname = $facts['fqdn']
   $com2sec = [ 'notConfigUser  default       public', ]
   $com2sec6 = [ 'notConfigUser  default       public', ]
   $groups = [
@@ -66,15 +66,15 @@ class snmp::params {
   $trap_service_hasrestart = true
   $snmpv2_enable = true
   $template_snmpd_conf = 'snmp/snmpd.conf.erb'
-  $template_snmpd_sysconfig = "snmp/snmpd.sysconfig-${facts['os']['family']}.erb"
+  $template_snmpd_sysconfig = "snmp/snmpd.sysconfig-${facts['osfamily']}.erb"
   $template_snmptrapd = 'snmp/snmptrapd.conf.erb'
-  $template_snmptrapd_sysconfig = "snmp/snmptrapd.sysconfig-${facts['os']['family']}.erb"
+  $template_snmptrapd_sysconfig = "snmp/snmptrapd.sysconfig-${facts['osfamily']}.erb"
 
-  $majordistrelease = $facts['os']['release']['major']
+  $majordistrelease = $facts['operatingsystemmajrelease']
 
-  case $facts['os']['family'] {
+  case $facts['osfamily'] {
     'RedHat': {
-      if $majordistrelease == '6' {
+      if $facts['operatingsystemmajrelease'] == '6' {
         $snmpd_options        = '-LS0-6d -Lf /dev/null -p /var/run/snmpd.pid'
         $sysconfig            = '/etc/sysconfig/snmpd'
         $trap_sysconfig       = '/etc/sysconfig/snmptrapd'
@@ -197,7 +197,7 @@ class snmp::params {
       $snmptrapd_options        = undef
     }
     default: {
-      fail("Module does not support ${facts['os']['family']}.")
+      fail("Module does not support ${facts['osfamily']}.")
     }
   }
 }


### PR DESCRIPTION
$facts['networking'] does not exist on all platforms.  For example, running the agent on a Fedora 27 node results in the following error.

[puppetserver] Puppet Evaluation Error: Operator '[]' is not applicable to an Undef Value. at /etc/puppetlabs/code/environments/production
/forge_modules/snmp/manifests/params.pp:27:14 on node foo.example.com