### PR TITLE
Updated stdlib to 4.22.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.22 < 6.0.0"
+      "version_requirement": ">= 4.22.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.22 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This module requires ensure::service, but ensure::service was not added until stdlib 4.22

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
  Updated the dependency for stdlib to version 4.22 because of ensure::service requirement.
-->

#### This Pull Request (PR) fixes the following issues
Fixes #178
