### PR TITLE
Mark `snmp::snmpv3_usm_hash` as private

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -15,7 +15,12 @@ configuration.
 
 **Functions**
 
-* [`snmp::snmpv3_usm_hash`](#snmpsnmpv3_usm_hash): snmpv3_usm_hash.rb --- Calculate SNMPv3 USM hash for a passphrase
+_Public Functions_
+
+
+_Private Functions_
+
+* `snmp::snmpv3_usm_hash`: snmpv3_usm_hash.rb --- Calculate SNMPv3 USM hash for a passphrase
 
 ## Classes
 
@@ -743,40 +748,4 @@ Which daemon file in which to write the user.  snmpd or snmptrapd
 Default value: 'snmpd'
 
 ## Functions
-
-### snmp::snmpv3_usm_hash
-
-Type: Ruby 4.x API
-
-snmpv3_usm_hash.rb --- Calculate SNMPv3 USM hash for a passphrase
-
-#### `snmp::snmpv3_usm_hash(String $authtype, String $engine, String $passphrase, Optional[Integer] $bits)`
-
-snmpv3_usm_hash.rb --- Calculate SNMPv3 USM hash for a passphrase
-
-Returns: `String` The calculated hash.
-
-##### `authtype`
-
-Data type: `String`
-
-The authentication type to calculate. This must either be
-
-##### `engine`
-
-Data type: `String`
-
-The SNMP engine used. The value is used as salt and must
-
-##### `passphrase`
-
-Data type: `String`
-
-The passphrase for which the hash is calculated.
-
-##### `bits`
-
-Data type: `Optional[Integer]`
-
-The number of bits the result should be truncated to if it is
 

--- a/lib/puppet/functions/snmp/snmpv3_usm_hash.rb
+++ b/lib/puppet/functions/snmp/snmpv3_usm_hash.rb
@@ -1,5 +1,6 @@
 # snmpv3_usm_hash.rb --- Calculate SNMPv3 USM hash for a passphrase
 Puppet::Functions.create_function(:'snmp::snmpv3_usm_hash') do
+  # @api private
   # Calculate SNMPv3 USM hash for a passphrase
   #
   # The algorithm is implemented according to RFC-3414 sections A.2.1/A.2.2.
@@ -19,23 +20,15 @@ Puppet::Functions.create_function(:'snmp::snmpv3_usm_hash') do
   # @return [String] The calculated hash.
   #
   dispatch :snmpv3_usm_hash do
-    required_param 'String', :authtype
+    required_param "Enum['SHA','MD5']", :authtype
     required_param 'String', :engine
-    required_param 'String', :passphrase
+    required_param 'String[8]', :passphrase
     optional_param 'Integer', :bits
     return_type 'String'
   end
 
   def snmpv3_usm_hash(authtype, engine, passphrase, bits = nil)
     require 'digest'
-
-    unless passphrase.length >= 8
-      call_function('fail', 'passphrase chosen is below the length requirements (min=8)')
-    end
-
-    unless %w[SHA MD5].include? authtype
-      call_function('fail', "authtype must be either 'SHA' or 'MD5'")
-    end
 
     # Create an instance of the selected digest
     digest_instance = case authtype


### PR DESCRIPTION
The `REFERENCE.md` docs for the function had lots of truncated lines.  I
think this function is private.  By marking `@api private`,
`REFERENCE.md` is cleaner.

Fixes #185