### PR TITLE
Suse 12 using systemd, not init for snmptrapd

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -406,7 +406,7 @@ class snmp (
     }
   }
 
-  if $facts['os']['family'] == 'Suse' {
+  if ($facts['os']['family'] == 'Suse') and (versioncmp($facts['os']['release']['major'], '12') < 0) {
     file { '/etc/init.d/snmptrapd':
       source  => '/usr/share/doc/packages/net-snmp/rc.snmptrapd',
       owner   => 'root',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Suse 12 using systemd, not init for snmptrapd

#### This Pull Request (PR) fixes the following issues

