### PR TITLE
Allow puppetlabs/stdlib 6.x; fix failing tests.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 6.0.0"
+      "version_requirement": ">= 4.25.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
* Changed `metadata.json` to allow `puppetlabs/stdlib 6.x`.
* Simplified [code](https://github.com/voxpupuli/puppet-snmp/pull/196/commits/76d2cc81aa58c9eaf39c07399220c6c1e3278af6?file-filters%5B%5D=.pp) that avoids a duplicate resource statement where the snmp server and client are in the same O/S package ([FreeBSD](https://github.com/voxpupuli/puppet-snmp/blob/master/data/os/FreeBSD.yaml#L3-L4), [OpenBSD](https://github.com/voxpupuli/puppet-snmp/blob/master/data/os/OpenBSD.yaml#L3-L4), and [Suse](https://github.com/voxpupuli/puppet-snmp/blob/master/data/os/Suse.yaml#L3-L4)).
* Fixed [failing test](https://travis-ci.org/voxpupuli/puppet-snmp/jobs/568094512).