### PR TITLE
Fix code and tests for FreeBSD and OpenBSD.

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,5 +296,3 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) for information on how to contribu
 * List of contributors https://github.com/voxpupuli/puppet-snmp/graphs/contributors
 
 Licensed under the Apache License, Version 2.0.
-
-This line added to demonstrate that tests fail with no code changes.

--- a/README.md
+++ b/README.md
@@ -296,3 +296,5 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) for information on how to contribu
 * List of contributors https://github.com/voxpupuli/puppet-snmp/graphs/contributors
 
 Licensed under the Apache License, Version 2.0.
+
+This line added to demonstrate that tests fail with no code changes.

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -49,13 +49,11 @@ class snmp::client (
     $file_ensure = 'absent'
   }
 
-  if $facts['os']['family'] != 'Suse' {
-    if $package_name != undef {
-      package { 'snmp-client':
-        ensure => $package_ensure,
-        name   => $package_name,
-        before => File['snmp.conf'],
-      }
+  if ($package_name != undef) and ($package_name != $snmp::package_name) {
+    package { 'snmp-client':
+      ensure => $package_ensure,
+      name   => $package_name,
+      before => File['snmp.conf'],
     }
   }
 

--- a/spec/classes/snmp_client_spec.rb
+++ b/spec/classes/snmp_client_spec.rb
@@ -44,7 +44,9 @@ describe 'snmp::client' do
           ).that_requires('Package[snmp-client]')
         }
       when 'Suse'
+        # rubocop:disable RSpec/RepeatedExample
         it { is_expected.not_to contain_package('snmp-client') }
+        # rubocop:enable RSpec/RepeatedExample
         it {
           is_expected.to contain_file('snmp.conf').with(
             ensure: 'present',
@@ -56,12 +58,9 @@ describe 'snmp::client' do
           )
         }
       when 'FreeBSD'
-        it {
-          is_expected.to contain_package('snmp-client').with(
-            ensure: 'present',
-            name: 'net-mgmt/net-snmp'
-          )
-        }
+        # rubocop:disable RSpec/RepeatedExample
+        it { is_expected.not_to contain_package('snmp-client') }
+        # rubocop:enable RSpec/RepeatedExample
         it {
           is_expected.not_to contain_file('snmp.conf').with(
             ensure: 'present',
@@ -72,12 +71,9 @@ describe 'snmp::client' do
           )
         }
       when 'OpenBSD'
-        it {
-          is_expected.to contain_package('snmp-client').with(
-            ensure: 'present',
-            name: 'net-snmp'
-          )
-        }
+        # rubocop:disable RSpec/RepeatedExample
+        it { is_expected.not_to contain_package('snmp-client') }
+        # rubocop:enable RSpec/RepeatedExample
         it {
           is_expected.not_to contain_file('snmp.conf').with(
             ensure: 'present',
@@ -99,7 +95,7 @@ describe 'snmp::client' do
 
       it { is_expected.to contain_file('snmp.conf').with_ensure('absent') }
       case facts[:os]['family']
-      when 'Suse'
+      when 'FreeBSD', 'OpenBSD', 'Suse'
         it { is_expected.not_to contain_package('snmp-client') }
       else
         it { is_expected.to contain_package('snmp-client').with_ensure('absent') }
@@ -114,7 +110,7 @@ describe 'snmp::client' do
 
       it { is_expected.to contain_file('snmp.conf').with_ensure('present') }
       case facts[:os]['family']
-      when 'Suse'
+      when 'FreeBSD', 'OpenBSD', 'Suse'
         it { is_expected.not_to contain_package('snmp-client') }
       else
         it { is_expected.to contain_package('snmp-client').with_ensure('latest') }


### PR DESCRIPTION
Produced in response to [@Dan33l comment](https://github.com/voxpupuli/puppet-snmp/pull/196#issuecomment-518664000).

* Demonstrate that tests fail [here](https://travis-ci.org/voxpupuli/puppet-snmp/jobs/568367082) and [here](https://travis-ci.org/voxpupuli/puppet-snmp/jobs/568367086) with a [trivial change](https://github.com/voxpupuli/puppet-snmp/pull/197/commits/8fa8496a7a25846b4aff5c2175cfcdf30490f966).
* [Revert](https://github.com/voxpupuli/puppet-snmp/pull/197/commits/8db267a5ba5cf4d80ecb9d7d799d7a04a9f37fb9) the trivial change.
* [Simplify code](https://github.com/voxpupuli/puppet-snmp/pull/197/commits/f95baad16151d2d049dac5180cfae381a2d5de92) that avoids a duplicate resource for [Suse](https://github.com/voxpupuli/puppet-snmp/blob/master/data/os/Suse.yaml#L3-L4), making it equally applicable to [FreeBSD](https://github.com/voxpupuli/puppet-snmp/blob/master/data/os/FreeBSD.yaml#L3-L4) and [OpenBSD](https://github.com/voxpupuli/puppet-snmp/blob/master/data/os/OpenBSD.yaml#L3-L4).
* Fix [tests](https://github.com/voxpupuli/puppet-snmp/pull/197/commits/c28f683fa9e01bbb8e9f02c53317d98f85ee1265) for FreeBSD and OpenBSD.