### PR TITLE
Allow puppetlabs/stdlib 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 6.0.0"
+      "version_requirement": ">= 4.25.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
* Change [`metadata.json`](https://github.com/voxpupuli/puppet-snmp/blob/master/metadata.json#L18) to allow [`puppetlabs/stdlib 6.x`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/metadata.json#L3).
