### PR TITLE
Set snmpd stop command based on the node's default service provider

### DIFF
--- a/manifests/snmpv3_user.pp
+++ b/manifests/snmpv3_user.pp
@@ -66,10 +66,10 @@ define snmp::snmpv3_user (
 
   if $create {
     unless defined(Exec["stop-${service_name}"]) {
-      #
-      # TODO: update $command for different operating systems/releases
-      #
-      $command = "service ${service_name} stop ; sleep 5"
+      $command = $facts['service_provider'] ? {
+        'systemd' => "systemctl stop ${service_name}; sleep 5",
+        default   => "service ${service_name} stop ; sleep 5",
+      }
 
       exec { "stop-${service_name}":
         command => $command,

--- a/spec/defines/snmp_snmpv3_user_spec.rb
+++ b/spec/defines/snmp_snmpv3_user_spec.rb
@@ -21,7 +21,6 @@ describe 'snmp::snmpv3_user' do
           it {
             is_expected.to contain_exec('stop-snmpd').with(
               path: '/bin:/sbin:/usr/bin:/usr/sbin',
-              command: 'service snmpd stop ; sleep 5',
               user: 'root'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]'])
 
@@ -50,7 +49,6 @@ describe 'snmp::snmpv3_user' do
           it {
             is_expected.to contain_exec('stop-snmpd').with(
               path: '/bin:/sbin:/usr/bin:/usr/sbin',
-              command: 'service snmpd stop ; sleep 5',
               user: 'root'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]'])
 
@@ -77,7 +75,6 @@ describe 'snmp::snmpv3_user' do
           it {
             is_expected.to contain_exec('stop-snmptrapd').with(
               path: '/bin:/sbin:/usr/bin:/usr/sbin',
-              command: 'service snmptrapd stop ; sleep 5',
               user: 'root'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]'])
 
@@ -103,7 +100,6 @@ describe 'snmp::snmpv3_user' do
           it {
             is_expected.to contain_exec('stop-snmpd').with(
               path: '/bin:/sbin:/usr/bin:/usr/sbin',
-              command: 'service snmpd stop ; sleep 5',
               user: 'root'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]'])
 
@@ -132,7 +128,6 @@ describe 'snmp::snmpv3_user' do
           it {
             is_expected.to contain_exec('stop-snmpd').with(
               path: '/bin:/sbin:/usr/bin:/usr/sbin',
-              command: 'service snmpd stop ; sleep 5',
               user: 'root'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]'])
 
@@ -159,7 +154,6 @@ describe 'snmp::snmpv3_user' do
           it {
             is_expected.to contain_exec('stop-snmpd').with(
               path: '/bin:/sbin:/usr/bin:/usr/sbin',
-              command: 'service snmpd stop ; sleep 5',
               user: 'root'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]'])
 
@@ -185,7 +179,6 @@ describe 'snmp::snmpv3_user' do
           it {
             is_expected.to contain_exec('stop-snmpd').with(
               path: '/bin:/sbin:/usr/bin:/usr/sbin',
-              command: 'service snmpd stop ; sleep 5',
               user: 'root'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]'])
 
@@ -214,7 +207,6 @@ describe 'snmp::snmpv3_user' do
           it {
             is_expected.to contain_exec('stop-snmpd').with(
               path: '/bin:/sbin:/usr/bin:/usr/sbin',
-              command: 'service snmpd stop ; sleep 5',
               user: 'root'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]'])
 
@@ -241,7 +233,6 @@ describe 'snmp::snmpv3_user' do
           it {
             is_expected.to contain_exec('stop-snmptrapd').with(
               path: '/bin:/sbin:/usr/bin:/usr/sbin',
-              command: 'service snmptrapd stop ; sleep 5',
               user: 'root'
             ).that_requires(['Package[snmpd]', 'File[var-net-snmp]'])
 


### PR DESCRIPTION
Redhat 8 nodes do not have a "service" command unless the initscripts package is installed.