### PR TITLE
Fix stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 7.0.0"
+      "version_requirement": ">= 5.2.0 < 7.0.0"
     },
     {
       "name": "camptocamp/systemd",


### PR DESCRIPTION
`Stdlib::IP::Address::V6::CIDR` was introduced in stdlib 5.2.0

Fixes #224