### PR TITLE
Drop EoL CentOS 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ See in file [REFERENCE.md](REFERENCE.md).
 
 Net-SNMP module support is available with these operating systems:
 
-* RedHat family  - tested on CentOS 6, CentOS 7
+* RedHat family  - tested on CentOS 7
 * SuSE family    - tested on SLES 11 SP1
 * Debian family  - tested on Debian 8, Debian 9, Ubuntu 14.04, Ubuntu 16.04, Ubuntu 18.04
 

--- a/data/os/RedHat/6.yaml
+++ b/data/os/RedHat/6.yaml
@@ -1,8 +1,0 @@
----
-snmp::service_config_perms: '0600'
-snmp::snmpd_options: '-LS0-6d -Lf /dev/null -p /var/run/snmpd.pid'
-snmp::snmptrapd_options: '-Lsd -p /var/run/snmptrapd.pid'
-snmp::sysconfig: '/etc/sysconfig/snmpd'
-snmp::trap_sysconfig: '/etc/sysconfig/snmptrapd'
-snmp::var_net_snmp: '/var/lib/net-snmp'
-snmp::varnetsnmp_perms: '0755'

--- a/metadata.json
+++ b/metadata.json
@@ -26,21 +26,18 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
It's EoL and the acceptance tests don't pass anymore.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
