### PR TITLE
Convert from `package` resource to `ensure_packages` to add flexibility to module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -398,7 +398,6 @@ class snmp (
 
   # Since ubuntu 16.04 platforms, there is a differente snmptrad package
   if ($snmp::snmptrapd_package_name) and ($manage_snmptrapd) {
-     # install snmptrapd
     ensure_packages(['snmptrapd'], {
         ensure => $package_ensure,
         name   => $snmp::snmptrapd_package_name,


### PR DESCRIPTION
#### Pull Request (PR) description
Converting from `package` resource to `ensure_packages` which will allow other puppet manifests which require `net-snmp` to declare them also using `ensure_packages` and prevent resource duplication errors. 

We have a base snmp profile we use across all nodes and is applied via a base role, our systems get `net-snmp` package this way. We have a need for a prometheus manifest to also require the `net-snmp` package and is resulting in duplicate resource declarations which is avoided by using `ensure_packages` in both manifests.

The use case is so we can use a prometheus manifest in an environment the snmp profile is not present, while at the same time using the same prometheus manifest in a different environment where the snmp profile does exist.