### PR TITLE
Set 'var-net-snmp' ensure to absent when removing snmp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -357,6 +357,7 @@ class snmp (
     $file_ensure = 'present'
     $trap_service_ensure_real = $trap_service_ensure
     $trap_service_enable_real = $trap_service_enable
+    $var_net_snmp_ensure = 'directory'
 
     # Make sure that if $trap_service_ensure == 'running' that
     # $service_ensure_real == 'running' on Debian.
@@ -374,6 +375,7 @@ class snmp (
     $service_enable_real = false
     $trap_service_ensure_real = 'stopped'
     $trap_service_enable_real = false
+    $var_net_snmp_ensure = absent
   }
 
   if $service_ensure == 'running' {
@@ -425,7 +427,7 @@ class snmp (
 
   if $var_net_snmp {
     file { 'var-net-snmp':
-      ensure  => 'directory',
+      ensure  => $var_net_snmp_ensure,
       path    => $var_net_snmp,
       owner   => $varnetsnmp_owner,
       group   => $varnetsnmp_group,

--- a/spec/classes/snmp_init_spec.rb
+++ b/spec/classes/snmp_init_spec.rb
@@ -163,7 +163,7 @@ describe 'snmp' do
 
           it { is_expected.to contain_package('snmpd').with_ensure('absent') }
           it { is_expected.not_to contain_class('snmp::client') }
-          it { is_expected.to contain_file('var-net-snmp').with_ensure('directory') }
+          it { is_expected.to contain_file('var-net-snmp').with_ensure('absent') }
           it { is_expected.to contain_file('snmpd.conf').with_ensure('absent') }
           it { is_expected.to contain_file('snmpd.sysconfig').with_ensure('absent') }
           it { is_expected.to contain_service('snmpd').with_ensure('stopped') }


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Previously `File[var-net-snmp]` was always getting set to `directory`, even when trying to remove snmp from a system. If the owner or group used for 'var-net-snmp' were removed before this, the resource would raise an error due to them missing.
If the ensure is set to `absent` it will not check for user/group existence.

<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
