### PR TITLE
Add Debian 12 (bookworm) support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Net-SNMP module support is available with these operating systems:
 
 * RedHat family  - tested on CentOS 7
 * SuSE family    - tested on SLES 11 SP1
-* Debian family  - tested on Debian 9, Debian 10, Debian 11, Ubuntu 18.04, Ubuntu 20.04
+* Debian family  - tested on Debian 9, Debian 10, Debian 11, Debian 12, Ubuntu 18.04, Ubuntu 20.04
 * FreeBSD family - tested on FreeBSD 12.2 (uses ports/pkgng Net-SNMP, not system bsnmpd)
 * Darwin family  - tested on Darwin 18 (macOS 10.14 "Mojave"), 19 (macOS 10.15 "Catalina"), and 20 (macOS 11.1 "Big Sur").
 
@@ -277,10 +277,6 @@ Net-SNMP module support is available with these operating systems:
 
 * By default the SNMP service now listens on BOTH the IPv4 and IPv6 loopback
   addresses.
-* There is a bug on Debian squeeze of net-snmp's status script. If snmptrapd is
-  not running the status script returns 'not running' so puppet restarts the
-  snmpd service. The following is a workaround: `class { 'snmp':
-  service_hasstatus => false, trap_service_hasstatus => false, }`
 * For security reasons, the SNMP daemons are configured to listen on the loopback
   interfaces (127.0.0.1 and [::1]).  Use `agentaddress` and `snmptrapdaddr` to change this
   configuration.

--- a/data/os/Debian/12.yaml
+++ b/data/os/Debian/12.yaml
@@ -1,0 +1,2 @@
+---
+snmp::snmpd_options: "-LOw -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf -f"

--- a/metadata.json
+++ b/metadata.json
@@ -60,6 +60,7 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
+        "12",
         "11",
         "10"
       ]

--- a/spec/classes/snmp_init_spec.rb
+++ b/spec/classes/snmp_init_spec.rb
@@ -575,7 +575,7 @@ describe 'snmp' do
           # TRAPDOPTS begins being set by the package in Ubuntu 22.04; we should not log a failure
           # in this case
           case facts[:os]['release']['major']
-          when '10', '11', '16.04', '18.04', '20.04'
+          when '10', '11', '12', '16.04', '18.04', '20.04'
             it { is_expected.to contain_file('snmpd.sysconfig').without_content(%r{TRAPDRUN|TRAPDOPTS}) }
           end
         end
@@ -628,7 +628,7 @@ describe 'snmp' do
         }
 
         case facts[:os]['release']['major']
-        when '10', '11', '16.04', '18.04', '20.04', '22.04'
+        when '10', '11', '12', '16.04', '18.04', '20.04', '22.04'
           it {
             is_expected.to contain_file('snmptrapd.sysconfig').with(
               ensure: 'present',
@@ -661,14 +661,24 @@ describe 'snmp' do
 
         case facts[:os]['release']['major']
         when '10', '11'
-          describe 'Debian-snmp as snmp user' do
-            it 'contains File[snmpd.sysconfig] with contents "SNMPDOPTS="-Lsd -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -smux -p /var/run/snmpd.pid""' do
-              verify_contents(catalogue, 'snmpd.sysconfig', [
-                                'SNMPDRUN=yes',
-                                'SNMPDOPTS=\'-Lsd -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf -f -p /run/snmpd.pid\''
-                              ])
-            end
+          it 'contains File[snmpd.sysconfig] with contents "SNMPDOPTS="-Lsd -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -smux -p /var/run/snmpd.pid""' do
+            verify_contents(catalogue, 'snmpd.sysconfig', [
+                              'SNMPDRUN=yes',
+                              'SNMPDOPTS=\'-Lsd -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf -f -p /run/snmpd.pid\''
+                            ])
+          end
+        when '12'
+          it 'contains File[snmpd.sysconfig] with contents "SNMPDOPTS="-Lsd -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -smux -p /var/run/snmpd.pid""' do
+            verify_contents(catalogue, 'snmpd.sysconfig', [
+                              'SNMPDRUN=yes',
+                              'SNMPDOPTS=\'-LOw -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf -f\''
+                            ])
+          end
+        end
 
+        case facts[:os]['release']['major']
+        when '10', '11', '12'
+          describe 'Debian-snmp as snmp user' do
             it {
               is_expected.to contain_file('var-net-snmp').with(
                 ensure: 'directory',


### PR DESCRIPTION
#### Pull Request (PR) description
Add Debian 12 support

A remark specific to Debian 6 (Squeeze), which is obsolete, has been removed from the Readme.