### PR TITLE
bugfix/invalid-ruby-syntax

### DIFF
--- a/lib/facter/snmpv3_user.rb
+++ b/lib/facter/snmpv3_user.rb
@@ -31,7 +31,7 @@ Facter.add(:snmpv3_user) do
 
         # convert hex string to ascii if necessary
         # handle '0x' prefix and trailing NULL
-        user = [user[2..]].pack('H*').delete("\000") if %r{^0x} =~ user
+        user = [user[2..-1]].pack('H*').delete("\000") if %r{^0x} =~ user
 
         # map OID to string for auth protocol
         authproto = case items[7]


### PR DESCRIPTION
Seeing the following error on Windows Puppet runs in Dev:
```
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Error: Facter: error while resolving custom facts in C:/ProgramData\PuppetLabs\puppet\var\lib\facter\snmpv3_user.rb: C:/ProgramData/PuppetLabs/puppet/var/lib/facter/snmpv3_user.rb:34: syntax error, unexpected ']'
        user = [user[2..]].pack('H*').delete("\000") i...
```

Greg recently updated this module in our Puppetfile from 6.0.0 to 7.1.0. It included this (unnecessarily) updated line:
https://github.com/voxpupuli/puppet-snmp/blob/v7.1.0/lib/facter/snmpv3_user.rb#L34

That infinite range notation was introduced in Ruby 2.6:
https://developer.squareup.com/blog/rubys-new-infinite-range-syntax-0/

Ruby 2.5.8 is installed on our Windows VMs
![Screenshot 2024-03-14 at 4 17 24 PM](https://github.com/voxpupuli/puppet-snmp/assets/6529107/22b79be9-f7b8-4cfb-91f6-87c6831a1b0f)

